### PR TITLE
Add Methods to Retrieve All Metadata Keys and Entries

### DIFF
--- a/contracts/IdentityRegistry.sol
+++ b/contracts/IdentityRegistry.sol
@@ -10,6 +10,12 @@ contract IdentityRegistry is ERC721URIStorage, Ownable {
     // agentId => key => value
     mapping(uint256 => mapping(string => bytes)) private _metadata;
 
+    // agentId => array of keys
+    mapping(uint256 => string[]) private _metadataKeys;
+
+    // agentId => key => index in _metadataKeys array (plus 1, 0 means not exists)
+    mapping(uint256 => mapping(string => uint256)) private _metadataKeyIndex;
+
     struct MetadataEntry {
         string key;
         bytes value;
@@ -41,9 +47,18 @@ contract IdentityRegistry is ERC721URIStorage, Ownable {
         emit Registered(agentId, tokenUri, msg.sender);
 
         for (uint256 i = 0; i < metadata.length; i++) {
-            _metadata[agentId][metadata[i].key] = metadata[i].value;
+            _setMetadataInternal(agentId, metadata[i].key, metadata[i].value);
             emit MetadataSet(agentId, metadata[i].key, metadata[i].key, metadata[i].value);
         }
+    }
+
+    function _setMetadataInternal(uint256 agentId, string memory key, bytes memory value) private {
+        // If key doesn't exist yet, add it to the keys array
+        if (_metadataKeyIndex[agentId][key] == 0) {
+            _metadataKeys[agentId].push(key);
+            _metadataKeyIndex[agentId][key] = _metadataKeys[agentId].length;
+        }
+        _metadata[agentId][key] = value;
     }
 
     function getMetadata(uint256 agentId, string memory key) external view returns (bytes memory) {
@@ -57,8 +72,26 @@ contract IdentityRegistry is ERC721URIStorage, Ownable {
             msg.sender == getApproved(agentId),
             "Not authorized"
         );
-        _metadata[agentId][key] = value;
+        _setMetadataInternal(agentId, key, value);
         emit MetadataSet(agentId, key, key, value);
+    }
+
+    function getAllMetadataKeys(uint256 agentId) external view returns (string[] memory) {
+        return _metadataKeys[agentId];
+    }
+
+    function getAllMetadata(uint256 agentId) external view returns (MetadataEntry[] memory) {
+        string[] memory keys = _metadataKeys[agentId];
+        MetadataEntry[] memory entries = new MetadataEntry[](keys.length);
+
+        for (uint256 i = 0; i < keys.length; i++) {
+            entries[i] = MetadataEntry({
+                key: keys[i],
+                value: _metadata[agentId][keys[i]]
+            });
+        }
+
+        return entries;
     }
 
     function setAgentUri(uint256 agentId, string calldata newUri) external {

--- a/contracts/IdentityRegistryUpgradeable.sol
+++ b/contracts/IdentityRegistryUpgradeable.sol
@@ -17,6 +17,12 @@ contract IdentityRegistryUpgradeable is
     // agentId => key => value
     mapping(uint256 => mapping(string => bytes)) private _metadata;
 
+    // agentId => array of keys
+    mapping(uint256 => string[]) private _metadataKeys;
+
+    // agentId => key => index in _metadataKeys array (plus 1, 0 means not exists)
+    mapping(uint256 => mapping(string => uint256)) private _metadataKeyIndex;
+
     struct MetadataEntry {
         string key;
         bytes value;
@@ -59,9 +65,18 @@ contract IdentityRegistryUpgradeable is
         emit Registered(agentId, tokenUri, msg.sender);
 
         for (uint256 i = 0; i < metadata.length; i++) {
-            _metadata[agentId][metadata[i].key] = metadata[i].value;
+            _setMetadataInternal(agentId, metadata[i].key, metadata[i].value);
             emit MetadataSet(agentId, metadata[i].key, metadata[i].key, metadata[i].value);
         }
+    }
+
+    function _setMetadataInternal(uint256 agentId, string memory key, bytes memory value) private {
+        // If key doesn't exist yet, add it to the keys array
+        if (_metadataKeyIndex[agentId][key] == 0) {
+            _metadataKeys[agentId].push(key);
+            _metadataKeyIndex[agentId][key] = _metadataKeys[agentId].length;
+        }
+        _metadata[agentId][key] = value;
     }
 
     function getMetadata(uint256 agentId, string memory key) external view returns (bytes memory) {
@@ -75,8 +90,26 @@ contract IdentityRegistryUpgradeable is
             msg.sender == getApproved(agentId),
             "Not authorized"
         );
-        _metadata[agentId][key] = value;
+        _setMetadataInternal(agentId, key, value);
         emit MetadataSet(agentId, key, key, value);
+    }
+
+    function getAllMetadataKeys(uint256 agentId) external view returns (string[] memory) {
+        return _metadataKeys[agentId];
+    }
+
+    function getAllMetadata(uint256 agentId) external view returns (MetadataEntry[] memory) {
+        string[] memory keys = _metadataKeys[agentId];
+        MetadataEntry[] memory entries = new MetadataEntry[](keys.length);
+
+        for (uint256 i = 0; i < keys.length; i++) {
+            entries[i] = MetadataEntry({
+                key: keys[i],
+                value: _metadata[agentId][keys[i]]
+            });
+        }
+
+        return entries;
     }
 
     function setAgentUri(uint256 agentId, string calldata newUri) external {


### PR DESCRIPTION
This PR adds two new public view methods to both IdentityRegistry and IdentityRegistryUpgradeable contracts to enable comprehensive metadata retrieval for agents.

## Motivation
Previously, there was no way to discover all metadata keys associated with an agent ID without knowing the keys in advance. Users had to maintain their own off-chain index or track keys through event logs, which is inefficient and error-prone.

## Changes

### New Storage Variables

- _metadataKeys: Tracks all metadata keys for each agent as an array
- _metadataKeyIndex: Provides O(1) lookup to prevent duplicate keys (stores array length, where 0 indicates key doesn't exist)

### New Methods

- getAllMetadataKeys(uint256 agentId): Returns an array of all metadata keys for a given agent
- getAllMetadata(uint256 agentId): Returns an array of MetadataEntry structs containing all key-value pairs for a given agent

## Refactoring
Introduced _setMetadataInternal() private helper function to ensure metadata keys are consistently tracked when set during registration or via setMetadata()

## Benefits

- Discoverability: Clients can now enumerate all metadata without prior knowledge of keys
- Efficiency: Batch retrieval of all metadata in a single call vs. multiple individual getMetadata() calls
- Gas Optimization: Using _metadataKeyIndex provides O(1) duplicate detection instead of O(n) array iteration
- Developer Experience: Simplifies building UIs and tools that need to display complete agent profiles
