### PR TITLE
Fix: Add missing getApproved() authorization check in ValidationRegistry

### DIFF
--- a/contracts/ValidationRegistry.sol
+++ b/contracts/ValidationRegistry.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 interface IIdentityRegistry {
     function ownerOf(uint256 tokenId) external view returns (address);
     function isApprovedForAll(address owner, address operator) external view returns (bool);
+    function getApproved(uint256 tokenId) external view returns (address);
 }
 
 /// @notice Minimal, compilable scaffold of ERC-8004 Validation Registry.
@@ -69,7 +70,9 @@ contract ValidationRegistry {
         IIdentityRegistry registry = IIdentityRegistry(identityRegistry);
         address owner = registry.ownerOf(agentId);
         require(
-            msg.sender == owner || registry.isApprovedForAll(owner, msg.sender),
+            msg.sender == owner || 
+            registry.isApprovedForAll(owner, msg.sender) ||
+            registry.getApproved(agentId) == msg.sender,
             "Not authorized"
         );
 

--- a/contracts/ValidationRegistryUpgradeable.sol
+++ b/contracts/ValidationRegistryUpgradeable.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 interface IIdentityRegistry {
     function ownerOf(uint256 tokenId) external view returns (address);
     function isApprovedForAll(address owner, address operator) external view returns (bool);
+    function getApproved(uint256 tokenId) external view returns (address);
 }
 
 contract ValidationRegistryUpgradeable is Initializable, OwnableUpgradeable, UUPSUpgradeable {
@@ -77,7 +78,9 @@ contract ValidationRegistryUpgradeable is Initializable, OwnableUpgradeable, UUP
         IIdentityRegistry registry = IIdentityRegistry(identityRegistry);
         address owner = registry.ownerOf(agentId);
         require(
-            msg.sender == owner || registry.isApprovedForAll(owner, msg.sender),
+            msg.sender == owner || 
+            registry.isApprovedForAll(owner, msg.sender) ||
+            registry.getApproved(agentId) == msg.sender,
             "Not authorized"
         );
 


### PR DESCRIPTION
- Added getApproved() to IIdentityRegistry interface
- Updated validationRequest() authorization check to include getApproved(agentId)
- Applied fix to both ValidationRegistry.sol and ValidationRegistryUpgradeable.sol

This allows ERC-721 token-specific approved operators to request validation, completing the standard ERC-721 operator pattern (owner, isApprovedForAll, getApproved).