### PR TITLE
Fix: Spec compliance - feedbackIndexes type and getValidationStatus return values

### DIFF
--- a/contracts/ReputationRegistryUpgradeable.sol
+++ b/contracts/ReputationRegistryUpgradeable.sol
@@ -240,7 +240,7 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
         bool includeRevoked
     ) external view returns (
         address[] memory clients,
-        uint8[] memory feedbackIndexes,
+        uint64[] memory feedbackIndexes,
         uint8[] memory scores,
         string[] memory tag1s,
         string[] memory tag2s,
@@ -274,7 +274,7 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
 
         // Initialize arrays
         clients = new address[](totalCount);
-        feedbackIndexes = new uint8[](totalCount);
+        feedbackIndexes = new uint64[](totalCount);
         scores = new uint8[](totalCount);
         tag1s = new string[](totalCount);
         tag2s = new string[](totalCount);
@@ -293,7 +293,7 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
                     tag2Hash != keccak256(bytes(fb.tag2))) continue;
 
                 clients[idx] = clientList[i];
-                feedbackIndexes[idx] = uint8(j);
+                feedbackIndexes[idx] = j;
                 scores[idx] = fb.score;
                 tag1s[idx] = fb.tag1;
                 tag2s[idx] = fb.tag2;

--- a/contracts/ValidationRegistryUpgradeable.sol
+++ b/contracts/ValidationRegistryUpgradeable.sol
@@ -137,12 +137,12 @@ contract ValidationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
     function getValidationStatus(bytes32 requestHash)
         external
         view
-        returns (address validatorAddress, uint256 agentId, uint8 response, bytes32 responseHash, string memory tag, uint256 lastUpdate)
+        returns (address validatorAddress, uint256 agentId, uint8 response, string memory tag, uint256 lastUpdate)
     {
         ValidationRegistryStorage storage $ = _getValidationRegistryStorage();
         ValidationStatus memory s = $.validations[requestHash];
         require(s.validatorAddress != address(0), "unknown");
-        return (s.validatorAddress, s.agentId, s.response, s.responseHash, s.tag, s.lastUpdate);
+        return (s.validatorAddress, s.agentId, s.response, s.tag, s.lastUpdate);
     }
 
     function getSummary(


### PR DESCRIPTION
## Summary

Two spec compliance fixes:

### 1. ReputationRegistry - `readAllFeedback()` wrong type (Critical)
- `feedbackIndexes` was `uint8[]` but spec requires `uint64[]`
- Fixes truncation bug where indices > 255 would overflow

### 2. ValidationRegistry - `getValidationStatus()` extra return value
- Was returning 6 values including `responseHash`
- Spec defines 5 return values (without `responseHash`)

## Spec References
- `readAllFeedback`: Line 256 of ERC8004SPEC.md
- `getValidationStatus`: Line 349 of ERC8004SPEC.md

## Files Changed
- `contracts/ReputationRegistryUpgradeable.sol`
- `contracts/ValidationRegistryUpgradeable.sol`