### PR TITLE
Add ERC-8004 EAS Extension for Attestation-Based Trust Signals (Refs #19)

### DIFF
--- a/ERC8004EXT-EAS.md
+++ b/ERC8004EXT-EAS.md
@@ -1,0 +1,269 @@
+# ERC-8004 Extension: Ethereum Attestation Service Integration
+
+**Extension for attestation-based trust using EAS**
+
+## Abstract
+
+This extension integrates Ethereum Attestation Service (EAS) into ERC-8004 to provide a standardized, composable trust layer for agents. It defines:
+
+1. **AgentURI → DID Address mapping** - Deterministic address derivation for EAS recipient indexing
+2. **Trust model integration** - How attestations complement the base ERC-8004 Reputation Registry
+
+This extension enables permissionless, multi-party attestations while maintaining compatibility with existing EAS infrastructure and tooling.
+
+## Motivation
+
+The base ERC-8004 Reputation Registry provides on-chain feedback storage for agents. This extension integrates Ethereum Attestation Service (EAS) to *extend* that foundation with additional capabilities:
+
+- **Standardized discovery & indexing**: EAS is deployed across multiple chains with well-known contract addresses and established indexing tooling, making it easier for clients to discover and query trust signals consistently.
+- **Greater expressiveness**: EAS supports an open-ended set of schemas, allowing different kinds of attestations (endorsements, certifications, audits, reviews, validations) without requiring a single fixed registry schema.
+- **Clearer semantics**: Schema UIDs and typed fields make the meaning of a trust signal explicit and machine-readable, improving interoperability across clients.
+- **Reuse of existing infrastructure**: EAS enables ERC-8004 deployments to leverage existing ecosystem contracts, explorers, and indexers rather than requiring separate bespoke infrastructure for each trust model.
+
+This extension is intentionally additive: it does not replace the Reputation Registry, and clients remain free to combine Reputation Registry feedback with EAS-based attestations according to their own trust policies.
+
+## Definitions
+
+The following terms are used throughout this specification:
+
+| Term                     | Definition                                                                                                                          |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Extension**            | This specification document.                                                                                                        |
+| **Base Specification**   | The [base ERC-8004 specification document](https://github.com/erc-8004/erc-8004-contracts/blob/master/ERC8004SPEC.md).              |
+| **EAS**                  | [Ethereum Attestation Service](https://attest.sh).                                                                                  |
+| **Identity Registry**    | The ERC-721 contract that stores agent registrations as defined in the Base Specification.                                          |
+| **Reputation Registry**  | The ERC-721 contract that stores agent feedback as defined in the Base Specification.                                               |
+| **Agent**                | A software service registered in the Identity Registry.                                                                             |
+| **Client**               | Software that queries the Extension to obtain information about an Agent. Examples include wallets, marketplaces, and other agents. |
+| **DID**                  | Decentralized Identifier as defined by the [W3C specification](https://www.w3.org/TR/did-core/#terminology).                        |
+| **canonicalDID**         | The normalized form of a DID string as defined in this Extension.                                                                   |
+| **didHash**              | The Keccak-256 hash of a canonicalDID as defined in this Extension.                                                                 |
+| **DID Address**          | A 20-byte value derived by truncating a didHash, for use as an EAS recipient. Defined in this Extension.                            |
+
+Terms defined in the Base Specification are incorporated by reference.
+
+## Background
+
+### What is a DID?
+
+A Decentralized Identifier (DID) is a globally unique identifier that does not require a centralized registration authority. DIDs are defined by the [W3C DID Core specification](https://www.w3.org/TR/did-core/). A DID consists of three parts: the scheme (`did:`), a method identifier, and a method-specific identifier. For example, `did:web:example.com` uses the `web` method with `example.com` as the method-specific identifier.
+
+This Extension uses the `did:web` method, which allows domain names and paths to be used as DIDs. The `did:web` method is specified in the [W3C DID Web Method specification](https://w3c-ccg.github.io/did-method-web/).
+
+### What is Ethereum Attestation Service?
+
+Ethereum Attestation Service (EAS) is an open-source, permissionless attestation infrastructure that enables anyone to make attestations on-chain or off-chain about anything. It was developed with support from the Ethereum Foundation and is maintained by a growing ecosystem of projects and developers.
+
+**Key Resources:**
+
+- **Website**: [https://attest.org](https://attest.org)
+- **Documentation**: [https://docs.attest.org](https://docs.attest.org)
+- **GitHub**: [https://github.com/ethereum-attestation-service](https://github.com/ethereum-attestation-service)
+- **Explorer**: [https://easscan.org](https://easscan.org)
+- **GraphQL Indexer**: [https://easscan.org/graphql](https://easscan.org/graphql)
+
+**Deployment Status:**
+
+The EAS team deployed EAS on multiple EVM-compatible chains including:
+
+- Ethereum Mainnet
+- Optimism
+- Base
+- Arbitrum
+- Polygon
+- Linea
+- Scroll
+
+EAS repositories are open-source, so many more unofficial deployments also exist. 
+
+**Semantics of `recipient` in EAS**
+
+In EAS, `recipient` represents the entity being attested to.  It is the same as "subject" in the DID specification.  EAS uses the Solidity type `address` for `recipient` as it is the only native identifier type in Solidity.  EAS uses the Solidity type address for recipient purely as a compact 20-byte identifier. The EAS protocol never interprets this as an executable account or owner. It is a data key, not a security principal. In practice, this means that the `recipient` value:
+
+- MAY correspond to an externally owned account (EOA) or smart contract
+- but also MAY represent a logical identity, such as a DID, an ERC-721 token, or another off-chain entity deterministically encoded into 20 bytes
+
+This background is important when reading this specification. 
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### DID Address
+
+In order to integrate EAS into ERC-8004, this Extension defines the formal use of the EAS `recipient` field as the generic identifier of a subject. This generic subject identifier uses a new logical identifier type: **DID Address**, a 20-byte value derived from a DID.  *agentURI* can be converted to a DID using the `did:web` method.
+
+DID Address:
+- Preserves determinism (same URI or DID always produces the same DID Address)
+- Ensures collision resistance (≈ 1 / 2^160 probability)
+- Fits naturally into EAS's existing `recipient` field size without requiring protocol changes
+
+**URI to DID**
+
+To convert a URL/URI to a `did:web` DID, the following algorithm MUST be used:
+
+1. Parse the URL to extract the hostname and path components
+2. The hostname MUST be converted to lowercase
+3. Leading and trailing slashes MUST be removed from the path
+4. Path separators (`/`) MUST be replaced with colons (`:`)
+5. The resulting DID MUST have the format `did:web:<hostname>[:<path-segments>]`
+
+**Conversion Examples:**
+
+| URL | DID |
+| --- | --- |
+| `https://agent.example.com` | `did:web:agent.example.com` |
+| `https://example.com/agents/myagent` | `did:web:example.com:agents:myagent` |
+| `https://example.com/.well-known/agent.json` | `did:web:example.com:.well-known:agent.json` |
+
+**DID Canonicalization**
+
+To ensure deterministic hashing, DIDs MUST be canonicalized before hashing. The canonicalization algorithm for `did:web` is as follows:
+
+1. The DID MUST start with the prefix `did:`
+2. The DID MUST contain at least three colon-separated parts: `did`, method, and method-specific identifier
+3. For `did:web`, the hostname portion MUST be converted to lowercase
+4. Path segments (if present) MUST preserve their original case
+
+**Canonicalization Examples:**
+
+| Input DID | Canonical DID |
+| --------- | ------------- |
+| `did:web:Example.COM` | `did:web:example.com` |
+| `did:web:Example.COM:Agents:MyAgent` | `did:web:example.com:Agents:MyAgent` |
+
+**DID Hash (didHash)**
+
+A `didHash` is a 32-byte value computed from a canonical DID. The computation algorithm MUST be performed as follows:
+
+1. Canonicalize the DID using the algorithm defined above
+2. Encode the canonical DID string as UTF-8 bytes
+3. Compute the Keccak-256 hash of the UTF-8 bytes
+4. The resulting 32-byte value is the `didHash`
+
+**DID Address Computation**
+
+A DID Address MUST be computed by truncating the didHash to 20 bytes. The computation algorithm is as follows:
+
+1. Compute the `didHash` from the canonical DID using the algorithm defined above
+2. Take the least significant 160 bits (last 20 bytes) of the didHash
+3. The resulting 20-byte value is the DID Address
+
+The DID Address can be used anywhere an `address` index is expected—EAS recipients, event partition keys, or contract mappings. Collision risk is negligible (≈ 1 / 2^160).
+
+**Solidity Example:**
+
+```solidity
+library DidIndex {
+    /// @notice Compute the DID Address used for EAS recipient or other address-keyed indexes.
+    /// @dev didHash = keccak256(abi.encodePacked(canonicalizeDID(did)))
+    function toAddress(bytes32 didHash) internal pure returns (address) {
+        return address(uint160(uint256(didHash)));
+    }
+}
+```
+
+**Reference Implementation:**
+
+A complete TypeScript implementation is provided in [`scripts/did-utils.ts`](./scripts/did-utils.ts).
+
+**Critical: DID Address is NOT a Wallet**
+
+The DID Address derived from a DID:
+- MUST NOT be interpreted as a signer or owner
+- MUST NOT receive asset transfers (ETH, tokens, NFTs)
+- MUST NOT be used for access control or permissions
+- SHOULD only be used as an EAS `recipient` for indexing and querying
+
+**Rationale**
+
+This usage of the EAS `recipient` enables efficient DID discovery in EAS. As long as an agent has a URL (e.g.- agentUri), anyone can:
+
+1. Convert the URL to a `did:web` DID
+2. Compute the `didHash`
+3. Derive the DID Address
+4. Create or search for attestations using that address as the EAS `recipient`
+
+## Schema Design
+
+When creating attestation schemas for DIDs, implementations MUST include a `subject` field in the schema definition. The `subject` field:
+
+- SHOULD use type `string` to store the full DID (e.g., `"did:web:example.com"`)
+- MUST be the DID that was used to derive the `recipient` address
+
+Why Both `recipient` and `subject`?
+
+- **`recipient` (address)**: EAS indexing key - enables efficient queries by DID Address
+- **`subject` (string)**: Verification field - proves attestation is about the correct DID
+
+This dual-field approach prevents spoofing attacks where an attacker could create attestations with a valid `recipient` but different `subject` content.
+
+## Standard Attestation Schemas
+
+This extension defines standard schemas for agent trust attestations. All schemas include the required `subject` field for DID verification.  These will be listed here in a future version of the Extension.
+
+## Attestation Querying
+
+Clients retrieve attestations about a DID using this flow:
+
+```javascript
+// 1. Compute DID Address
+const didAddress = didToAddress(did);
+
+// 2. Query EAS for attestations
+const attestations = await eas.getAttestations({
+    recipient: didAddress,
+    schemaUID: SCHEMA_UID_USER_REVIEW
+});
+
+// 3. Verify each attestation
+for (const attestation of attestations) {
+    const payload = decodeAttestationData(attestation.data);
+    
+    // MUST verify subject matches
+    if (payload.subject !== did) {
+        throw new Error("DID hash mismatch");
+    }
+    
+    // Process valid attestation
+    processAttestation(payload);
+}
+```
+
+Clients MAY index EAS attestations by DID Address using subgraphs or EAS GraphQL endpoints.
+
+Example query filters: recipient=<didAddress>, schema=<schemaUID>.”
+
+**Verification Requirements:**
+
+Clients MUST verify:
+1. `recipient` equals `didAddress(did)`
+2. `subject` in payload equals the `did` used to derive recipient
+3. Attestation is not revoked
+4. Attestation is not expired (if `expirationTime` is set)
+5. Attester is trusted (per client's trust policy)
+
+
+## Future Direction: EAS v2 Migration Path
+
+The current v1 EAS Extension uses a DID address as the value of the subject field in order to remain compatible with the canonical EAS contract interface, which strictly defines subject as an address.
+
+This approach allows ERC-8004 identity registries and DIDs to participate in the EAS ecosystem today, but it is a transitional mechanism, not a permanent design choice. The DID address format is only a proxy representation of a DID or registry identifier—it was never intended to be a spendable or externally owned account, and implementations MUST treat it as a non-transferable identifier rather than a wallet address.
+
+In v2, the EAS extension will migrate away from this workaround toward a more flexible subject model that allows:
+
+- Native support for non-address subject types such as bytes32 (DID hashes), string (canonicalized DIDs), or structured identifiers (e.g., CAIP-19 asset references).
+- A unified attestation schema capable of expressing cross-chain and cross-namespace subjects.
+- Optional backward compatibility for v1 DID address subjects through SDK-level resolution.
+
+This evolution is not a competing alternative to v1, but a planned migration path. The v1 approach ensures interoperability with existing EAS deployments. The v2 framework defines the long-term direction for EAS-compatible attestations across heterogeneous identifiers, registries, and chains.
+
+Implementations integrating this specification should plan to:
+
+- Continue supporting DID address subjects for legacy attestations.
+- Add support for resolving v2 subject types as they become available.
+- Transition indexers and SDKs to a unified query layer that transparently handles both v1 and v2 attestations.
+
+## Copyright
+
+Copyright and related rights waived via CC0.

--- a/ERC8004EXT-EAS.md
+++ b/ERC8004EXT-EAS.md
@@ -38,7 +38,7 @@ The following terms are used throughout this specification:
 | **DID**                  | Decentralized Identifier as defined by the [W3C specification](https://www.w3.org/TR/did-core/#terminology).                        |
 | **canonicalDID**         | The normalized form of a DID string as defined in this Extension.                                                                   |
 | **didHash**              | The Keccak-256 hash of a canonicalDID as defined in this Extension.                                                                 |
-| **DID Address**          | A 20-byte value derived by truncating a didHash, for use as an EAS recipient. Defined in this Extension.                            |
+| **DID Address**          | An EAS recipient `bytes20` value derived by truncating a didHash. See *Output Encoding (Normative)* for serialization rules.        |
 
 Terms defined in the Base Specification are incorporated by reference.
 
@@ -150,6 +150,18 @@ A DID Address MUST be computed by truncating the didHash to 20 bytes. The comput
 3. The resulting 20-byte value is the DID Address
 
 The DID Address can be used anywhere an `address` index is expected—EAS recipients, event partition keys, or contract mappings. Collision risk is negligible (≈ 1 / 2^160).
+
+**Output Encoding (Normative)**
+
+The DID Address is conceptually a 20-byte value (`bytes20`).
+
+When serialized as a string, it MUST be:
+
+- `0x`-prefixed
+- lowercase
+- exactly 40 hexadecimal characters
+
+EIP-55 checksum casing MUST NOT be required.
 
 **Solidity Example:**
 

--- a/ERC8004EXT-EAS.md
+++ b/ERC8004EXT-EAS.md
@@ -7,7 +7,9 @@
 This extension integrates Ethereum Attestation Service (EAS) into ERC-8004 to provide a standardized, composable trust layer for agents. It defines:
 
 1. **AgentURI → DID Address mapping** - Deterministic address derivation for EAS recipient indexing
-2. **Trust model integration** - How attestations complement the base ERC-8004 Reputation Registry
+2. **Off-chain attestation querying** - How off-chain clients discover and verify EAS attestations using DID Addresses
+3. **On-chain attestation indexing** - How the Reputation Registry serves as an on-chain index into EAS, enabling smart contract verifiers to discover and retrieve attestations by agentId
+4. **Trust model integration** - How attestations complement the base ERC-8004 Reputation Registry
 
 This extension enables permissionless, multi-party attestations while maintaining compatibility with existing EAS infrastructure and tooling.
 
@@ -19,6 +21,7 @@ The base ERC-8004 Reputation Registry provides on-chain feedback storage for age
 - **Greater expressiveness**: EAS supports an open-ended set of schemas, allowing different kinds of attestations (endorsements, certifications, audits, reviews, validations) without requiring a single fixed registry schema.
 - **Clearer semantics**: Schema UIDs and typed fields make the meaning of a trust signal explicit and machine-readable, improving interoperability across clients.
 - **Reuse of existing infrastructure**: EAS enables ERC-8004 deployments to leverage existing ecosystem contracts, explorers, and indexers rather than requiring separate bespoke infrastructure for each trust model.
+- **On-chain composability**: By indexing EAS attestation references in the Reputation Registry, smart contracts can discover and retrieve attestations without relying on off-chain indexers.
 
 This extension is intentionally additive: it does not replace the Reputation Registry, and clients remain free to combine Reputation Registry feedback with EAS-based attestations according to their own trust policies.
 
@@ -32,7 +35,7 @@ The following terms are used throughout this specification:
 | **Base Specification**   | The [base ERC-8004 specification document](https://github.com/erc-8004/erc-8004-contracts/blob/master/ERC8004SPEC.md).              |
 | **EAS**                  | [Ethereum Attestation Service](https://attest.sh).                                                                                  |
 | **Identity Registry**    | The ERC-721 contract that stores agent registrations as defined in the Base Specification.                                          |
-| **Reputation Registry**  | The ERC-721 contract that stores agent feedback as defined in the Base Specification.                                               |
+| **Reputation Registry**  | The contract that stores agent feedback as defined in the Base Specification.                                                        |
 | **Agent**                | A software service registered in the Identity Registry.                                                                             |
 | **Client**               | Software that queries the Extension to obtain information about an Agent. Examples include wallets, marketplaces, and other agents. |
 | **DID**                  | Decentralized Identifier as defined by the [W3C specification](https://www.w3.org/TR/did-core/#terminology).                        |
@@ -214,12 +217,17 @@ This dual-field approach prevents spoofing attacks where an attacker could creat
 
 This extension defines standard schemas for agent trust attestations. All schemas include the required `subject` field for DID verification.  These will be listed here in a future version of the Extension.
 
-## Attestation Querying
+
+## Off-Chain Attestation Discovery
+
+This section describes how off-chain clients (wallets, marketplaces, agent orchestrators, and other software running outside the EVM) discover and verify EAS attestations for agents. Off-chain clients have access to EAS GraphQL indexers and RPC endpoints, so they can query attestations directly using the DID Address as the EAS `recipient`.
+
+### Querying Flow
 
 Clients retrieve attestations about a DID using this flow:
 
 ```javascript
-// 1. Compute DID Address
+// 1. Compute DID Address from the agent's URI or DID
 const didAddress = didToAddress(did);
 
 // 2. Query EAS for attestations
@@ -244,9 +252,9 @@ for (const attestation of attestations) {
 
 Clients MAY index EAS attestations by DID Address using subgraphs or EAS GraphQL endpoints.
 
-Example query filters: recipient=<didAddress>, schema=<schemaUID>.”
+Example query filters: `recipient=<didAddress>`, `schema=<schemaUID>`.
 
-**Verification Requirements:**
+### Verification Requirements
 
 Clients MUST verify:
 1. `recipient` equals `didAddress(did)`
@@ -256,25 +264,165 @@ Clients MUST verify:
 5. Attester is trusted (per client's trust policy)
 
 
-## Future Direction: EAS v2 Migration Path
+## On-Chain Attestation Discovery
 
-The current v1 EAS Extension uses a DID address as the value of the subject field in order to remain compatible with the canonical EAS contract interface, which strictly defines subject as an address.
+This section describes how on-chain clients (smart contract verifiers, automated agents, and other contracts) discover and retrieve EAS attestations for agents. Unlike off-chain clients, smart contracts cannot query EAS GraphQL indexers or RPC endpoints. They need a way to discover attestation UIDs from an `agentId` using only on-chain state.
 
-This approach allows ERC-8004 identity registries and DIDs to participate in the EAS ecosystem today, but it is a transitional mechanism, not a permanent design choice. The DID address format is only a proxy representation of a DID or registry identifier—it was never intended to be a spendable or externally owned account, and implementations MUST treat it as a non-transferable identifier rather than a wallet address.
+The Reputation Registry's `giveFeedback()` function serves as this on-chain index. When an EAS attestation is created for an agent, the attestation creator (or any third party) also records a feedback entry in the Reputation Registry that references the attestation. This creates a fully on-chain discovery path from `agentId` to EAS attestation.
 
-In v2, the EAS extension will migrate away from this workaround toward a more flexible subject model that allows:
+### Reputation Registry Field Conventions
 
-- Native support for non-address subject types such as bytes32 (DID hashes), string (canonicalized DIDs), or structured identifiers (e.g., CAIP-19 asset references).
-- A unified attestation schema capable of expressing cross-chain and cross-namespace subjects.
-- Optional backward compatibility for v1 DID address subjects through SDK-level resolution.
+The Reputation Registry's `tag1` and `tag2` fields are stored in contract storage and are readable by smart contracts via `readFeedback()` and `readAllFeedback()`. This extension defines the following conventions for EAS-indexed feedback entries:
 
-This evolution is not a competing alternative to v1, but a planned migration path. The v1 approach ensures interoperability with existing EAS deployments. The v2 framework defines the long-term direction for EAS-compatible attestations across heterogeneous identifiers, registries, and chains.
+**`tag1`: Reputation Framework Identifier**
 
-Implementations integrating this specification should plan to:
+`tag1` MUST be set to `"eas"` for feedback entries that reference EAS attestations.
 
-- Continue supporting DID address subjects for legacy attestations.
-- Add support for resolving v2 subject types as they become available.
-- Transition indexers and SDKs to a unified query layer that transparently handles both v1 and v2 attestations.
+`tag1` serves as a framework discriminator. It identifies the format and semantics of `tag2`. Other reputation frameworks MAY define their own `tag1` values (e.g., future frameworks could use different identifiers). The value of `tag1` tells the verifier how to interpret `tag2`.
+
+**`tag2`: Attestation Reference**
+
+`tag2` encodes the EAS attestation UID and, optionally, the chain and contract location of the attestation. The format is:
+
+```
+<uid>[:<chainId>[:<easContractAddress>]]
+```
+
+Where:
+- `uid` (REQUIRED): The EAS attestation UID, a `bytes32` value encoded as a `0x`-prefixed, lowercase hex string (66 characters).
+- `chainId` (OPTIONAL): The EVM chain ID where the attestation exists, as a decimal string (e.g., `1` for Ethereum mainnet). If omitted, the attestation is assumed to be on the same chain as the Reputation Registry.
+- `easContractAddress` (OPTIONAL): The address of the EAS contract, as a `0x`-prefixed, lowercase hex string (42 characters). If omitted, the well-known official EAS contract address for the specified chain MUST be used. This field is only needed for unofficial or custom EAS deployments.
+
+`chainId` MUST be present if `easContractAddress` is present.
+
+**`tag2` Examples:**
+
+| Scenario                                    | `tag2` value                          |
+| ------------------------------------------- | ------------------------------------- |
+| Same chain, official EAS                    | `0xabc123...def`                      |
+| Different chain (Base), official EAS        | `0xabc123...def:8453`                 |
+| Different chain, unofficial EAS deployment  | `0xabc123...def:8453:0x5678...ef01`   |
+
+> **Note on CAIP-10 compatibility:** A future revision of this extension MAY adopt a CAIP-10-aligned format by prepending the `eip155:` namespace prefix before the chain ID (e.g., `0xabc123...def:eip155:8453:0x5678...ef01`). The current format omits the namespace prefix because EAS is exclusively an EVM technology, making the prefix redundant. However, there are advantages to including the namespace prefix as it would make the fields after `uid` CAIP-10 compliant.
+
+> **Note on gas efficiency:** The current `tag2` encoding uses a human-readable string format, which is convenient for off-chain tooling but not gas-efficient for on-chain parsing. A future revision MAY adopt a more compact encoding (e.g., ABI-encoded `bytes` or a packed binary format) to reduce storage and parsing costs for on-chain verifiers.
+
+### Recording an EAS Attestation in the Reputation Registry
+
+When an EAS attestation is created for an agent, the attestation creator (or any party) SHOULD also call `giveFeedback()` on the Reputation Registry to index the attestation on-chain:
+
+```solidity
+reputationRegistry.giveFeedback(
+    agentId,                    // The agent's Identity Registry token ID
+    value,                      // Feedback value (e.g., rating from the attestation)
+    valueDecimals,              // Decimal precision of the value
+    "eas",                      // tag1: framework identifier
+    tag2,                       // tag2: "<uid>" or "<uid>:<chainId>" or "<uid>:<chainId>:<contractAddress>"
+    endpoint,                   // OPTIONAL: agent endpoint reviewed (emitted, not stored)
+    feedbackURI,                // OPTIONAL: URI to off-chain feedback file (emitted, not stored)
+    feedbackHash                // OPTIONAL: hash of feedbackURI content (emitted, not stored)
+);
+```
+
+The `value` and `valueDecimals` fields SHOULD reflect the attestation's primary signal (e.g., a rating value from a user review schema). This ensures that `getSummary()` can aggregate EAS-backed feedback alongside native Reputation Registry feedback.
+
+### On-Chain Verification Flow
+
+A verifier contract can discover and retrieve EAS attestations for an agent using the following pattern:
+
+```solidity
+// Step 1: Verify registry linkage
+require(
+    reputationRegistry.getIdentityRegistry() == expectedIdentityRegistry,
+    "Registry mismatch"
+);
+
+// Step 2: Read EAS-tagged feedback entries
+(
+    address[] memory clients,
+    uint64[] memory feedbackIndexes,
+    int128[] memory values,
+    uint8[] memory valueDecimals,
+    string[] memory tag1s,
+    string[] memory tag2s,
+    bool[] memory revokedStatuses
+) = reputationRegistry.readAllFeedback(
+    agentId,
+    trustedReviewers,   // Filter to trusted reviewer addresses
+    "eas",              // tag1 filter: only EAS-backed entries
+    "",                 // tag2 filter: empty = no additional filtering
+    false               // exclude revoked
+);
+
+// Step 3: Derive the expected DID Address from the agent's URI
+string memory agentURI = identityRegistry.tokenURI(agentId);
+address expectedDIDAddress = EASIndex.uriToDIDAddress(agentURI);
+
+// Step 4: For each entry, parse tag2 and retrieve the attestation
+for (uint256 i = 0; i < clients.length; i++) {
+    EASIndex.AttestationRef memory ref = EASIndex.parseTag2(tag2s[i]);
+    
+    // Skip cross-chain attestations (cannot verify on-chain)
+    if (ref.chainId != 0 && ref.chainId != block.chainid) continue;
+    
+    // Retrieve the attestation from EAS
+    Attestation memory attestation = eas.getAttestation(ref.uid);
+    
+    // Skip revoked attestations
+    if (attestation.revocationTime != 0) continue;
+    
+    // Verify the attestation's recipient matches the agent's DID Address
+    if (attestation.recipient != expectedDIDAddress) continue;
+    
+    // Schema-specific verification
+    // (e.g., check expiration, decode rating, verify proof of payment, etc.)
+    // ...
+}
+```
+
+### EAS Index Library Interface
+
+This extension defines a Solidity library interface for parsing `tag2` and resolving EAS attestations. The implementation is deferred to a future version of this extension.
+
+```solidity
+/// @title EASIndex
+/// @notice Library for parsing Reputation Registry tag2 values that reference EAS attestations.
+library EASIndex {
+
+    struct AttestationRef {
+        bytes32 uid;              // EAS attestation UID
+        uint256 chainId;          // 0 = same chain as Reputation Registry
+        address easContract;      // address(0) = use well-known EAS contract
+    }
+
+    /// @notice Parse a tag2 string into its component parts.
+    /// @param tag2 The tag2 value from a Reputation Registry feedback entry where tag1 = "eas".
+    /// @return ref The parsed attestation reference.
+    function parseTag2(string memory tag2) internal pure returns (AttestationRef memory ref);
+
+    /// @notice Retrieve an EAS attestation from a parsed reference.
+    /// @dev Only works for same-chain attestations. Reverts if chainId != 0 and does not match block.chainid.
+    /// @param ref The parsed attestation reference.
+    /// @return attestation The full EAS Attestation struct.
+    function getAttestation(AttestationRef memory ref) internal view returns (Attestation memory attestation);
+
+    /// @notice Convert an HTTPS URI (e.g., agentURI) to a DID Address.
+    /// @dev Converts URI to did:web, canonicalizes, computes keccak256, and truncates to 20 bytes.
+    ///      Example: "https://agent.example.com/v1/chat" -> 0x...
+    /// @param uri The HTTPS URI to convert.
+    /// @return didAddress The 20-byte DID Address derived from the URI.
+    function uriToDIDAddress(string memory uri) internal pure returns (address didAddress);
+}
+```
+
+### Cross-Chain Limitations
+
+On-chain attestation retrieval via `EASIndex.getAttestation()` is only possible when the attestation resides on the same chain as the Reputation Registry. If `tag2` specifies a different `chainId`, the on-chain verifier cannot directly retrieve the attestation.
+
+For cross-chain scenarios, verifiers MUST either:
+- Trust the Reputation Registry feedback entry as a proxy signal (the `value` and `valueDecimals` fields reflect the attestation's content)
+- Use an off-chain relay or oracle to verify the attestation on the remote chain
+- Require attestations to be created on the same chain as the Reputation Registry
 
 ## Copyright
 

--- a/ERC8004EXT-EAS.md
+++ b/ERC8004EXT-EAS.md
@@ -7,21 +7,20 @@
 This extension integrates Ethereum Attestation Service (EAS) into ERC-8004 to provide a standardized, composable trust layer for agents. It defines:
 
 1. **AgentURI → DID Address mapping** - Deterministic address derivation for EAS recipient indexing
-2. **Off-chain attestation querying** - How off-chain clients discover and verify EAS attestations using DID Addresses
-3. **On-chain attestation indexing** - How the Reputation Registry serves as an on-chain index into EAS, enabling smart contract verifiers to discover and retrieve attestations by agentId
-4. **Trust model integration** - How attestations complement the base ERC-8004 Reputation Registry
+2. **Onchain attestation indexing** - How the Reputation Registry serves as an onchain index into EAS, enabling smart contract verifiers to discover and retrieve attestations by agentId
+3. **Verification paths** - How both offchain and onchain verifiers discover and validate EAS attestations for agents
 
 This extension enables permissionless, multi-party attestations while maintaining compatibility with existing EAS infrastructure and tooling.
 
 ## Motivation
 
-The base ERC-8004 Reputation Registry provides on-chain feedback storage for agents. This extension integrates Ethereum Attestation Service (EAS) to *extend* that foundation with additional capabilities:
+The base ERC-8004 Reputation Registry provides onchain feedback storage for agents. This extension integrates Ethereum Attestation Service (EAS) to *extend* that foundation with additional capabilities:
 
 - **Standardized discovery & indexing**: EAS is deployed across multiple chains with well-known contract addresses and established indexing tooling, making it easier for clients to discover and query trust signals consistently.
 - **Greater expressiveness**: EAS supports an open-ended set of schemas, allowing different kinds of attestations (endorsements, certifications, audits, reviews, validations) without requiring a single fixed registry schema.
 - **Clearer semantics**: Schema UIDs and typed fields make the meaning of a trust signal explicit and machine-readable, improving interoperability across clients.
 - **Reuse of existing infrastructure**: EAS enables ERC-8004 deployments to leverage existing ecosystem contracts, explorers, and indexers rather than requiring separate bespoke infrastructure for each trust model.
-- **On-chain composability**: By indexing EAS attestation references in the Reputation Registry, smart contracts can discover and retrieve attestations without relying on off-chain indexers.
+- **Onchain composability**: By indexing EAS attestation references in the Reputation Registry, smart contracts can discover and retrieve attestations without relying on offchain indexers.
 
 This extension is intentionally additive: it does not replace the Reputation Registry, and clients remain free to combine Reputation Registry feedback with EAS-based attestations according to their own trust policies.
 
@@ -35,7 +34,7 @@ The following terms are used throughout this specification:
 | **Base Specification**   | The [base ERC-8004 specification document](https://github.com/erc-8004/erc-8004-contracts/blob/master/ERC8004SPEC.md).              |
 | **EAS**                  | [Ethereum Attestation Service](https://attest.sh).                                                                                  |
 | **Identity Registry**    | The ERC-721 contract that stores agent registrations as defined in the Base Specification.                                          |
-| **Reputation Registry**  | The contract that stores agent feedback as defined in the Base Specification.                                                        |
+| **Reputation Registry**  | The contract that stores agent feedback as defined in the Base Specification.                                                       |
 | **Agent**                | A software service registered in the Identity Registry.                                                                             |
 | **Client**               | Software that queries the Extension to obtain information about an Agent. Examples include wallets, marketplaces, and other agents. |
 | **DID**                  | Decentralized Identifier as defined by the [W3C specification](https://www.w3.org/TR/did-core/#terminology).                        |
@@ -55,7 +54,7 @@ This Extension uses the `did:web` method, which allows domain names and paths to
 
 ### What is Ethereum Attestation Service?
 
-Ethereum Attestation Service (EAS) is an open-source, permissionless attestation infrastructure that enables anyone to make attestations on-chain or off-chain about anything. It was developed with support from the Ethereum Foundation and is maintained by a growing ecosystem of projects and developers.
+Ethereum Attestation Service (EAS) is an open-source, permissionless attestation infrastructure that enables anyone to make attestations onchain or offchain about anything. It was developed with support from the Ethereum Foundation and is maintained by a growing ecosystem of projects and developers.
 
 **Key Resources:**
 
@@ -84,7 +83,7 @@ EAS repositories are open-source, so many more unofficial deployments also exist
 In EAS, `recipient` represents the entity being attested to.  It is the same as "subject" in the DID specification.  EAS uses the Solidity type `address` for `recipient` as it is the only native identifier type in Solidity.  EAS uses the Solidity type address for recipient purely as a compact 20-byte identifier. The EAS protocol never interprets this as an executable account or owner. It is a data key, not a security principal. In practice, this means that the `recipient` value:
 
 - MAY correspond to an externally owned account (EOA) or smart contract
-- but also MAY represent a logical identity, such as a DID, an ERC-721 token, or another off-chain entity deterministically encoded into 20 bytes
+- but also MAY represent a logical identity, such as a DID, an ERC-721 token, or another offchain entity deterministically encoded into 20 bytes
 
 This background is important when reading this specification. 
 
@@ -113,11 +112,11 @@ To convert a URL/URI to a `did:web` DID, the following algorithm MUST be used:
 
 **Conversion Examples:**
 
-| URL | DID |
-| --- | --- |
-| `https://agent.example.com` | `did:web:agent.example.com` |
-| `https://example.com/agents/myagent` | `did:web:example.com:agents:myagent` |
-| `https://example.com/.well-known/agent.json` | `did:web:example.com:.well-known:agent.json` |
+| URL                                           | DID                                              |
+| --------------------------------------------- | ------------------------------------------------ |
+| `https://agent.example.com`                   | `did:web:agent.example.com`                      |
+| `https://example.com/agents/myagent`          | `did:web:example.com:agents:myagent`             |
+| `https://example.com/.well-known/agent.json`  | `did:web:example.com:.well-known:agent.json`     |
 
 **DID Canonicalization**
 
@@ -130,9 +129,9 @@ To ensure deterministic hashing, DIDs MUST be canonicalized before hashing. The 
 
 **Canonicalization Examples:**
 
-| Input DID | Canonical DID |
-| --------- | ------------- |
-| `did:web:Example.COM` | `did:web:example.com` |
+| Input DID                            | Canonical DID                        |
+| ------------------------------------ | ------------------------------------ |
+| `did:web:Example.COM`                | `did:web:example.com`                |
 | `did:web:Example.COM:Agents:MyAgent` | `did:web:example.com:Agents:MyAgent` |
 
 **DID Hash (didHash)**
@@ -170,9 +169,12 @@ EIP-55 checksum casing MUST NOT be required.
 
 ```solidity
 library DidIndex {
-    /// @notice Compute the DID Address used for EAS recipient or other address-keyed indexes.
-    /// @dev didHash = keccak256(abi.encodePacked(canonicalizeDID(did)))
-    function toAddress(bytes32 didHash) internal pure returns (address) {
+    /// @notice Convert an HTTPS URI to a DID Address for EAS recipient indexing.
+    /// @dev Converts URI to did:web, canonicalizes, computes keccak256, and truncates to 20 bytes.
+    function uriToDIDAddress(string memory uri) internal pure returns (address) {
+        string memory did = _uriToDID(uri);
+        string memory canonicalDid = _canonicalize(did);
+        bytes32 didHash = keccak256(abi.encodePacked(canonicalDid));
         return address(uint160(uint256(didHash)));
     }
 }
@@ -199,9 +201,9 @@ This usage of the EAS `recipient` enables efficient DID discovery in EAS. As lon
 3. Derive the DID Address
 4. Create or search for attestations using that address as the EAS `recipient`
 
-## Schema Design
+### Schema Design
 
-When creating attestation schemas for DIDs, implementations MUST include a `subject` field in the schema definition. The `subject` field:
+When creating EAS schemas for DIDs, implementations MUST include a `subject` field in the schema definition. The `subject` field:
 
 - SHOULD use type `string` to store the full DID (e.g., `"did:web:example.com"`)
 - MUST be the DID that was used to derive the `recipient` address
@@ -213,64 +215,17 @@ Why Both `recipient` and `subject`?
 
 This dual-field approach prevents spoofing attacks where an attacker could create attestations with a valid `recipient` but different `subject` content.
 
-## Standard Attestation Schemas
+### Standard Attestation Schemas
 
 This extension defines standard schemas for agent trust attestations. All schemas include the required `subject` field for DID verification.  These will be listed here in a future version of the Extension.
 
+### Onchain Indexing via Reputation Registry
 
-## Off-Chain Attestation Discovery
+Smart contracts cannot query EAS GraphQL indexers or RPC endpoints. They need a way to discover attestation UIDs from an `agentId` using only onchain state. The Reputation Registry's `giveFeedback()` function serves as this onchain index.
 
-This section describes how off-chain clients (wallets, marketplaces, agent orchestrators, and other software running outside the EVM) discover and verify EAS attestations for agents. Off-chain clients have access to EAS GraphQL indexers and RPC endpoints, so they can query attestations directly using the DID Address as the EAS `recipient`.
+When an EAS attestation is created for an agent, the attestation creator (or any third party) MAY record a feedback entry in the Reputation Registry that references the attestation. This creates a fully onchain discovery path from `agentId` to EAS attestation.
 
-### Querying Flow
-
-Clients retrieve attestations about a DID using this flow:
-
-```javascript
-// 1. Compute DID Address from the agent's URI or DID
-const didAddress = didToAddress(did);
-
-// 2. Query EAS for attestations
-const attestations = await eas.getAttestations({
-    recipient: didAddress,
-    schemaUID: SCHEMA_UID_USER_REVIEW
-});
-
-// 3. Verify each attestation
-for (const attestation of attestations) {
-    const payload = decodeAttestationData(attestation.data);
-    
-    // MUST verify subject matches
-    if (payload.subject !== did) {
-        throw new Error("DID hash mismatch");
-    }
-    
-    // Process valid attestation
-    processAttestation(payload);
-}
-```
-
-Clients MAY index EAS attestations by DID Address using subgraphs or EAS GraphQL endpoints.
-
-Example query filters: `recipient=<didAddress>`, `schema=<schemaUID>`.
-
-### Verification Requirements
-
-Clients MUST verify:
-1. `recipient` equals `didAddress(did)`
-2. `subject` in payload equals the `did` used to derive recipient
-3. Attestation is not revoked
-4. Attestation is not expired (if `expirationTime` is set)
-5. Attester is trusted (per client's trust policy)
-
-
-## On-Chain Attestation Discovery
-
-This section describes how on-chain clients (smart contract verifiers, automated agents, and other contracts) discover and retrieve EAS attestations for agents. Unlike off-chain clients, smart contracts cannot query EAS GraphQL indexers or RPC endpoints. They need a way to discover attestation UIDs from an `agentId` using only on-chain state.
-
-The Reputation Registry's `giveFeedback()` function serves as this on-chain index. When an EAS attestation is created for an agent, the attestation creator (or any third party) also records a feedback entry in the Reputation Registry that references the attestation. This creates a fully on-chain discovery path from `agentId` to EAS attestation.
-
-### Reputation Registry Field Conventions
+#### Reputation Registry Field Conventions
 
 The Reputation Registry's `tag1` and `tag2` fields are stored in contract storage and are readable by smart contracts via `readFeedback()` and `readAllFeedback()`. This extension defines the following conventions for EAS-indexed feedback entries:
 
@@ -305,11 +260,11 @@ Where:
 
 > **Note on CAIP-10 compatibility:** A future revision of this extension MAY adopt a CAIP-10-aligned format by prepending the `eip155:` namespace prefix before the chain ID (e.g., `0xabc123...def:eip155:8453:0x5678...ef01`). The current format omits the namespace prefix because EAS is exclusively an EVM technology, making the prefix redundant. However, there are advantages to including the namespace prefix as it would make the fields after `uid` CAIP-10 compliant.
 
-> **Note on gas efficiency:** The current `tag2` encoding uses a human-readable string format, which is convenient for off-chain tooling but not gas-efficient for on-chain parsing. A future revision MAY adopt a more compact encoding (e.g., ABI-encoded `bytes` or a packed binary format) to reduce storage and parsing costs for on-chain verifiers.
+> **Note on gas efficiency:** The current `tag2` encoding uses a human-readable string format, which is convenient for offchain tooling but not gas-efficient for onchain parsing. A future revision MAY adopt a more compact encoding (e.g., ABI-encoded `bytes` or a packed binary format) to reduce storage and parsing costs for onchain verifiers.
 
-### Recording an EAS Attestation in the Reputation Registry
+#### Recording an EAS Attestation
 
-When an EAS attestation is created for an agent, the attestation creator (or any party) SHOULD also call `giveFeedback()` on the Reputation Registry to index the attestation on-chain:
+When an EAS attestation is created for an agent, the attestation creator (or any party) SHOULD also call `giveFeedback()` on the Reputation Registry to index the attestation onchain:
 
 ```solidity
 reputationRegistry.giveFeedback(
@@ -319,14 +274,71 @@ reputationRegistry.giveFeedback(
     "eas",                      // tag1: framework identifier
     tag2,                       // tag2: "<uid>" or "<uid>:<chainId>" or "<uid>:<chainId>:<contractAddress>"
     endpoint,                   // OPTIONAL: agent endpoint reviewed (emitted, not stored)
-    feedbackURI,                // OPTIONAL: URI to off-chain feedback file (emitted, not stored)
+    feedbackURI,                // OPTIONAL: URI to offchain feedback file (emitted, not stored)
     feedbackHash                // OPTIONAL: hash of feedbackURI content (emitted, not stored)
 );
 ```
 
 The `value` and `valueDecimals` fields SHOULD reflect the attestation's primary signal (e.g., a rating value from a user review schema). This ensures that `getSummary()` can aggregate EAS-backed feedback alongside native Reputation Registry feedback.
 
-### On-Chain Verification Flow
+## Verification
+
+This section describes how verifiers discover and validate EAS attestations for agents. There are two paths depending on whether the verifier is an offchain client or an onchain smart contract.
+
+### Offchain Verification
+
+Offchain clients (wallets, marketplaces, agent orchestrators, and other software running outside the EVM) can query EAS directly using the DID Address as the EAS `recipient`. They have access to EAS GraphQL indexers and RPC endpoints.
+
+#### Querying Flow
+
+Clients retrieve attestations about an agent using this flow:
+
+```javascript
+// 1. If starting from an agentId, retrieve the agent's URI from the Identity Registry
+const agentURI = await identityRegistry.tokenURI(agentId);
+
+// 2. Convert the agent URI to a DID, then to a DID Address
+const did = uriToDid(agentURI);           // e.g., "did:web:agent.example.com"
+const didAddress = didToAddress(did);      // 20-byte DID Address
+
+// 3. Query EAS for all attestations about this agent
+const attestations = await eas.getAttestations({
+    recipient: didAddress
+});
+
+// 4. Optionally filter by schema UID
+const reviews = attestations.filter(a => a.schema === SCHEMA_UID_USER_REVIEW);
+
+// 5. Verify each attestation
+for (const attestation of reviews) {
+    const payload = decodeAttestationData(attestation.data);
+    
+    // MUST verify subject matches the DID
+    if (payload.subject !== did) continue;
+    
+    // Process valid attestation
+    processAttestation(payload);
+}
+```
+
+Clients MAY also start from a known DID or URI directly (skipping step 1). Clients MAY index EAS attestations by DID Address using subgraphs or EAS GraphQL endpoints.
+
+Example query filters: `recipient=<didAddress>`, optionally `schema=<schemaUID>`.
+
+#### Verification Requirements
+
+Clients MUST verify:
+1. `recipient` equals `didAddress(did)`
+2. `subject` in payload equals the `did` used to derive recipient
+3. Attestation is not revoked
+4. Attestation is not expired (if `expirationTime` is set)
+5. Attester is trusted (per client's trust policy)
+
+### Onchain Verification
+
+Onchain verifiers (smart contracts) cannot query EAS indexers directly. Instead, they use the Reputation Registry as an index to discover EAS attestation UIDs, then retrieve and validate the attestations onchain.
+
+#### Verification Flow
 
 A verifier contract can discover and retrieve EAS attestations for an agent using the following pattern:
 
@@ -362,7 +374,7 @@ address expectedDIDAddress = EASIndex.uriToDIDAddress(agentURI);
 for (uint256 i = 0; i < clients.length; i++) {
     EASIndex.AttestationRef memory ref = EASIndex.parseTag2(tag2s[i]);
     
-    // Skip cross-chain attestations (cannot verify on-chain)
+    // Skip cross-chain attestations (cannot verify onchain)
     if (ref.chainId != 0 && ref.chainId != block.chainid) continue;
     
     // Retrieve the attestation from EAS
@@ -380,7 +392,7 @@ for (uint256 i = 0; i < clients.length; i++) {
 }
 ```
 
-### EAS Index Library Interface
+#### EAS Index Library Interface
 
 This extension defines a Solidity library interface for parsing `tag2` and resolving EAS attestations. The implementation is deferred to a future version of this extension.
 
@@ -417,11 +429,11 @@ library EASIndex {
 
 ### Cross-Chain Limitations
 
-On-chain attestation retrieval via `EASIndex.getAttestation()` is only possible when the attestation resides on the same chain as the Reputation Registry. If `tag2` specifies a different `chainId`, the on-chain verifier cannot directly retrieve the attestation.
+Onchain attestation retrieval via `EASIndex.getAttestation()` is only possible when the attestation resides on the same chain as the Reputation Registry. If `tag2` specifies a different `chainId`, the onchain verifier cannot directly retrieve the attestation.
 
 For cross-chain scenarios, verifiers MUST either:
 - Trust the Reputation Registry feedback entry as a proxy signal (the `value` and `valueDecimals` fields reflect the attestation's content)
-- Use an off-chain relay or oracle to verify the attestation on the remote chain
+- Use an offchain relay or oracle to verify the attestation on the remote chain
 - Require attestations to be created on the same chain as the Reputation Registry
 
 ## Copyright

--- a/scripts/did-utils.ts
+++ b/scripts/did-utils.ts
@@ -1,0 +1,131 @@
+/**
+ * DID Address Utilities
+ * 
+ * Implements the ERC-8004 EAS Extension specification for converting DIDs
+ * to deterministic Ethereum addresses for EAS recipient indexing.
+ * 
+ * Transformation chain: URL → DID → canonicalDID → didHash → DID Address
+ */
+
+import { keccak256, toBytes, getAddress, type Address } from 'viem'
+
+/**
+ * Convert a URL to a did:web DID
+ * @param url - The URL to convert
+ * @returns DID in did:web format
+ */
+export function urlToDid(url: string): string {
+  const urlObj = new URL(url)
+  const host = urlObj.hostname.toLowerCase()
+  const path = urlObj.pathname.replace(/^\//, '').replace(/\/$/, '')
+
+  if (path) {
+    return `did:web:${host}:${path.replace(/\//g, ':')}`
+  }
+  return `did:web:${host}`
+}
+
+/**
+ * Canonicalize a DID according to its method specification
+ * @param did - The DID string to canonicalize
+ * @returns Canonicalized DID string
+ */
+export function canonicalizeDID(did: string): string {
+  if (!did.startsWith('did:')) {
+    throw new Error('Invalid DID format: must start with "did:"')
+  }
+
+  const parts = did.split(':')
+  if (parts.length < 3) {
+    throw new Error('Invalid DID format: insufficient parts')
+  }
+
+  const method = parts[1]
+
+  switch (method) {
+    case 'web': {
+      // For did:web, lowercase the host and preserve the path
+      const methodSpecificId = parts.slice(2).join(':')
+      const colonIndex = methodSpecificId.indexOf(':')
+
+      if (colonIndex === -1) {
+        // No path segments, just hostname
+        return `did:web:${methodSpecificId.toLowerCase()}`
+      }
+
+      const host = methodSpecificId.substring(0, colonIndex).toLowerCase()
+      const pathSegments = methodSpecificId.substring(colonIndex + 1)
+
+      return `did:web:${host}:${pathSegments}`
+    }
+
+    case 'pkh': {
+      // For did:pkh, use canonical CAIP-10 encoding (lowercase address)
+      if (parts.length !== 5) {
+        throw new Error('Invalid did:pkh format: must have 5 parts')
+      }
+      const [, , namespace, chainId, address] = parts
+      return `did:pkh:${namespace}:${chainId}:${address.toLowerCase()}`
+    }
+
+    default:
+      // For other methods, lowercase the entire DID
+      return did.toLowerCase()
+  }
+}
+
+/**
+ * Compute the DID hash using keccak256
+ * @param did - The DID string (will be canonicalized)
+ * @returns 32-byte hash as hex string
+ */
+export function computeDidHash(did: string): `0x${string}` {
+  const canonicalDid = canonicalizeDID(did)
+  return keccak256(toBytes(canonicalDid))
+}
+
+/**
+ * Compute the DID Address by truncating didHash to 20 bytes
+ * @param didHash - The keccak256 hash of the canonicalized DID
+ * @returns Checksummed Ethereum address
+ */
+export function computeDidAddress(didHash: `0x${string}`): Address {
+  // Take the last 20 bytes (40 hex chars) to form an address
+  const addressHex = `0x${didHash.slice(-40)}` as `0x${string}`
+  return getAddress(addressHex)
+}
+
+/**
+ * Convert a DID directly to a DID Address
+ * @param did - The DID string
+ * @returns Checksummed Ethereum address for use as EAS recipient
+ */
+export function didToAddress(did: string): Address {
+  const didHash = computeDidHash(did)
+  return computeDidAddress(didHash)
+}
+
+/**
+ * Convert a URL directly to a DID Address
+ * @param url - The URL to convert
+ * @returns Checksummed Ethereum address for use as EAS recipient
+ */
+export function urlToDidAddress(url: string): Address {
+  const did = urlToDid(url)
+  return didToAddress(did)
+}
+
+/**
+ * Validate that a DID Address was computed correctly
+ * @param did - The original DID
+ * @param address - The address to validate
+ * @returns True if the address matches the DID
+ */
+export function validateDidAddress(did: string, address: string): boolean {
+  try {
+    const expectedAddress = didToAddress(did)
+    return expectedAddress.toLowerCase() === address.toLowerCase()
+  } catch {
+    return false
+  }
+}

--- a/scripts/did-utils.ts
+++ b/scripts/did-utils.ts
@@ -10,12 +10,12 @@
 import { keccak256, toBytes, getAddress, type Address } from 'viem'
 
 /**
- * Convert a URL to a did:web DID
- * @param url - The URL to convert
+ * Convert a URI to a did:web DID
+ * @param uri - The URI to convert
  * @returns DID in did:web format
  */
-export function urlToDid(url: string): string {
-  const urlObj = new URL(url)
+export function uriToDid(uri: string): string {
+  const urlObj = new URL(uri)
   const host = urlObj.hostname.toLowerCase()
   const path = urlObj.pathname.replace(/^\//, '').replace(/\/$/, '')
 
@@ -106,12 +106,12 @@ export function didToAddress(did: string): Address {
 }
 
 /**
- * Convert a URL directly to a DID Address
- * @param url - The URL to convert
+ * Convert a URI directly to a DID Address
+ * @param uri - The URI to convert
  * @returns Checksummed Ethereum address for use as EAS recipient
  */
-export function urlToDidAddress(url: string): Address {
-  const did = urlToDid(url)
+export function uriToDidAddress(uri: string): Address {
+  const did = uriToDid(uri)
   return didToAddress(did)
 }
 


### PR DESCRIPTION
## Description

This PR introduces an **Ethereum Attestation Service (EAS) extension** to ERC-8004, enabling the use of attestations as a flexible, composable trust signal alongside the existing Reputation Registry.

The goal of this extension is to make ERC-8004 interoperable with the broader attestation ecosystem, supporting use cases such as endorsements, certifications, and audits without modifying core contracts or prescribing trust policy.

### Key points:

* **Additive and optional**: Does not replace or deprecate the Reputation Registry.
* **Spec-only**: No changes to existing ERC-8004 contracts.
* **EAS-native**: Leverages established EAS schemas, contracts, and indexing infrastructure.

## What’s included

* New extension specification: `ERC8004EXT-EAS.md`
* TypeScript reference examples for issuing and verifying attestations

## Related Issue

* References: **[#19](https://github.com/erc-8004/erc-8004-contracts/issues/19)**

This PR is intended to start a concrete, implementation-grounded discussion around attestations in ERC-8004. Feedback welcome.
