### PR TITLE
fix: initialize ownership in upgradeable registries

### DIFF
--- a/contracts/IdentityRegistryUpgradeable.sol
+++ b/contracts/IdentityRegistryUpgradeable.sol
@@ -51,7 +51,9 @@ contract IdentityRegistryUpgradeable is
         _disableInitializers();
     }
 
-    function initialize() public reinitializer(2) onlyOwner {
+    function initialize() public reinitializer(2) {
+        __Ownable_init(msg.sender);
+        __UUPSUpgradeable_init();
         __ERC721_init("AgentIdentity", "AGENT");
         __ERC721URIStorage_init();
         __EIP712_init("ERC8004IdentityRegistry", "1");

--- a/contracts/ReputationRegistryUpgradeable.sol
+++ b/contracts/ReputationRegistryUpgradeable.sol
@@ -83,7 +83,9 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
         _disableInitializers();
     }
 
-    function initialize(address identityRegistry_) public reinitializer(2) onlyOwner {
+    function initialize(address identityRegistry_) public reinitializer(2) {
+        __Ownable_init(msg.sender);
+        __UUPSUpgradeable_init();
         require(identityRegistry_ != address(0), "bad identity");
         _identityRegistry = identityRegistry_;
     }

--- a/contracts/ValidationRegistryUpgradeable.sol
+++ b/contracts/ValidationRegistryUpgradeable.sol
@@ -66,7 +66,9 @@ contract ValidationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
         _disableInitializers();
     }
 
-    function initialize(address identityRegistry_) public reinitializer(2) onlyOwner {
+    function initialize(address identityRegistry_) public reinitializer(2) {
+        __Ownable_init(msg.sender);
+        __UUPSUpgradeable_init();
         require(identityRegistry_ != address(0), "bad identity");
         _identityRegistry = identityRegistry_;
     }


### PR DESCRIPTION
This fixes a critical initialization issue: initialize() was onlyOwner but ownership wasn’t set, so direct proxy deployments revert. The fix initializes Ownable + UUPS state inside initialize() for all registries while preserving the reinitializer(2) upgrade path used by the MinimalUUPS pattern.

### Changes
- Set owner and UUPS state in IdentityRegistryUpgradeable.initialize()
- Set owner and UUPS state in ReputationRegistryUpgradeable.initialize()
- Set owner and UUPS state in ValidationRegistryUpgradeable.initialize()
### Tests
Not run (optional: npm test or npx hardhat test)