### PR TITLE
docs: remove duplicate Polygon Amoy entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 - **IdentityRegistry**: to be deployed
 - **ReputationRegistry**: to be deployed
 
-#### Polygon Amoy
-- **IdentityRegistry**: to be deployed
-- **ReputationRegistry**: to be deployed
-
 #### Hedera Testnet
 - **IdentityRegistry**: to be deployed
 - **ReputationRegistry**: to be deployed


### PR DESCRIPTION
## Summary
Remove duplicate Polygon Amoy entry from README.md

## Changes
- Removed the second "Polygon Amoy" section (lines 34-36) which had "to be deployed" status
- Kept the first Polygon Amoy section (lines 22-24) which has the correct deployed contract addresses

## Before
```
#### Polygon Amoy
- **IdentityRegistry**: [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](...)
- **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](...)

...

#### Polygon Amoy  <-- duplicate
- **IdentityRegistry**: to be deployed
- **ReputationRegistry**: to be deployed
```

## After
```
#### Polygon Amoy
- **IdentityRegistry**: [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](...)
- **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](...)
```