### PR TITLE
docs: add Solana mainnet implementation (SATI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 - **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://testnet.bscscan.com/address/0x8004B663056A597Dffe9eCcC1965A193B7388713)
 
 
+#### Solana Mainnet — [SATI](https://github.com/cascade-protocol/sati)
+
+Solana-native implementation of ERC-8004 semantics (Anchor/Rust). Single program handles identity, reputation, and validation using Token-2022 for agent NFTs and Light Protocol for compressed attestation storage.
+
+- **Program**: [`satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe`](https://solscan.io/account/satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe)
+- **SDK**: [@cascade-fyi/sati-sdk](https://www.npmjs.com/package/@cascade-fyi/sati-sdk)
+- **Docs**: [cascade-protocol.github.io/sati](https://cascade-protocol.github.io/sati/specification.html)
+
+| ERC-8004 Registry | SATI Equivalent |
+|-------------------|-----------------|
+| Identity Registry | Token-2022 NFT with TokenGroup (`register_agent`, ERC-8004 compatible registration file) |
+| Reputation Registry | Compressed attestations via Light Protocol (`giveFeedback`, `getSummary` via Photon RPC) |
+| Validation Registry | Compressed attestations via Light Protocol (`ValidationV1` schema) |
+
+
 More chains coming soon...
 
 

--- a/README.md
+++ b/README.md
@@ -87,18 +87,10 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 
 
 #### Solana Mainnet — [SATI](https://github.com/cascade-protocol/sati)
-
-Solana-native implementation of ERC-8004 semantics (Anchor/Rust). Single program handles identity, reputation, and validation using Token-2022 for agent NFTs and Light Protocol for compressed attestation storage.
-
 - **Program**: [`satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe`](https://solscan.io/account/satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe)
-- **SDK**: [@cascade-fyi/sati-sdk](https://www.npmjs.com/package/@cascade-fyi/sati-sdk)
-- **Docs**: [cascade-protocol.github.io/sati](https://cascade-protocol.github.io/sati/specification.html)
 
-| ERC-8004 Registry | SATI Equivalent |
-|-------------------|-----------------|
-| Identity Registry | Token-2022 NFT with TokenGroup (`register_agent`, ERC-8004 compatible registration file) |
-| Reputation Registry | Compressed attestations via Light Protocol (`giveFeedback`, `getSummary` via Photon RPC) |
-| Validation Registry | Compressed attestations via Light Protocol (`ValidationV1` schema) |
+#### Solana Devnet — [SATI](https://github.com/cascade-protocol/sati)
+- **Program**: [`satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe`](https://solscan.io/account/satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe?cluster=devnet)
 
 
 More chains coming soon...


### PR DESCRIPTION
## Summary

Adds [SATI](https://github.com/cascade-protocol/sati) (Solana Agent Trust Infrastructure) as a Solana implementation of ERC-8004. Mainnet and devnet program addresses.

## Changes

Added Solana Mainnet and Devnet program address to README.md:

| Network | Address |
|---------|---------|
| Mainnet | [`satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe`](https://solscan.io/account/satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe) |
| Devnet | [`satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe`](https://solscan.io/account/satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe?cluster=devnet) |

---

## Implementation Details

SATI maps ERC-8004's three-registry architecture to Solana-native primitives via a single Anchor program:

| ERC-8004 Registry | SATI Equivalent |
|-------------------|-----------------|
| Identity Registry | Token-2022 NFT with TokenGroup (`register_agent`, ERC-8004 compatible registration file) |
| Reputation Registry | Compressed attestations via Light Protocol (`giveFeedback`, `getSummary` via Photon RPC) |
| Validation Registry | Compressed attestations via Light Protocol (`ValidationV1` schema) |

- **Single program** handles all registries. Solana's account model separates state by PDA derivation, so separate programs would add complexity without benefit.
- **Compressed storage** via Light Protocol for feedback and validation attestations (~$0.002 per attestation). Score aggregates use regular Solana Attestation Service accounts.
- **ERC-8004 compatible** registration file format and functional interfaces.

---

## Links

- Repository: https://github.com/cascade-protocol/sati
- SDK: https://www.npmjs.com/package/@cascade-fyi/sati-sdk
- Docs: https://cascade-protocol.github.io/sati/specification.html
- Solana Explorer: https://solscan.io/account/satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe