### PR TITLE
docs: add TRON mainnet and Shasta contract addresses (TRC-8004)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 - **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://taikoscan.io/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
 - **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://taikoscan.io/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)
 
+#### TRON Mainnet
+- **IdentityRegistry**: [`THmfi8uJuUpTfUmYLDX7UD1KaE4P6HKgqA`](https://tronscan.org/#/contract/THmfi8uJuUpTfUmYLDX7UD1KaE4P6HKgqA)
+- **ReputationRegistry**: [`TV8KWmp8qcj55sjs1NSjVxmRmZP7CYzNxH`](https://tronscan.org/#/contract/TV8KWmp8qcj55sjs1NSjVxmRmZP7CYzNxH)
+- **ValidationRegistry**: [`TCoJA4BYXWZhp5eanCchMw67VA83tQ83n1`](https://tronscan.org/#/contract/TCoJA4BYXWZhp5eanCchMw67VA83tQ83n1)
+- **IncidentRegistry**: [`TJ26Pu24ar7Qdh9Bm6tbBVdtzCJkbxS5eR`](https://tronscan.org/#/contract/TJ26Pu24ar7Qdh9Bm6tbBVdtzCJkbxS5eR)
+
+#### TRON Shasta (Testnet)
+- **IdentityRegistry**: [`TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7`](https://shasta.tronscan.org/#/contract/TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7)
+- **ReputationRegistry**: [`TRaYogyr2qc7WgsmuVF5Js39aCmoG7vZrA`](https://shasta.tronscan.org/#/contract/TRaYogyr2qc7WgsmuVF5Js39aCmoG7vZrA)
+- **ValidationRegistry**: [`TPgGWWyUdxNryUCN49TdT4b3F4WB3Edr16`](https://shasta.tronscan.org/#/contract/TPgGWWyUdxNryUCN49TdT4b3F4WB3Edr16)
+- **IncidentRegistry**: [`TPB59NFdypBpkJtWH7yE8XenKrdT1Q4g4s`](https://shasta.tronscan.org/#/contract/TPB59NFdypBpkJtWH7yE8XenKrdT1Q4g4s)
+
 #### Monad Mainnet
 - **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://monadscan.com/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
 - **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://monadscan.com/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 - **IncidentRegistry**: [`TJ26Pu24ar7Qdh9Bm6tbBVdtzCJkbxS5eR`](https://tronscan.org/#/contract/TJ26Pu24ar7Qdh9Bm6tbBVdtzCJkbxS5eR)
 
 #### TRON Shasta (Testnet)
-- **IdentityRegistry**: [`TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7`](https://shasta.tronscan.org/#/contract/TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7)
-- **ReputationRegistry**: [`TRaYogyr2qc7WgsmuVF5Js39aCmoG7vZrA`](https://shasta.tronscan.org/#/contract/TRaYogyr2qc7WgsmuVF5Js39aCmoG7vZrA)
-- **ValidationRegistry**: [`TPgGWWyUdxNryUCN49TdT4b3F4WB3Edr16`](https://shasta.tronscan.org/#/contract/TPgGWWyUdxNryUCN49TdT4b3F4WB3Edr16)
-- **IncidentRegistry**: [`TPB59NFdypBpkJtWH7yE8XenKrdT1Q4g4s`](https://shasta.tronscan.org/#/contract/TPB59NFdypBpkJtWH7yE8XenKrdT1Q4g4s)
+- **IdentityRegistry**: [`TFjkYo3ymRoSk1zp2vNqbddRsY7UzQWbve`](https://shasta.tronscan.org/#/contract/TFjkYo3ymRoSk1zp2vNqbddRsY7UzQWbve)
+- **ReputationRegistry**: [`TULtprdriMpQNpGNAJe9ceD8JrN3GH31tL`](https://shasta.tronscan.org/#/contract/TULtprdriMpQNpGNAJe9ceD8JrN3GH31tL)
+- **ValidationRegistry**: [`TMKi3HWmtoBnAMNnoJ2wyFdYmXuMRHTp3j`](https://shasta.tronscan.org/#/contract/TMKi3HWmtoBnAMNnoJ2wyFdYmXuMRHTp3j)
+- **IncidentRegistry**: [`TV8GvfDNzrhj76aqT9XM522KnYtaDLik3f`](https://shasta.tronscan.org/#/contract/TV8GvfDNzrhj76aqT9XM522KnYtaDLik3f)
 
 #### Monad Mainnet
 - **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://monadscan.com/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ERC-8004: Trustless Agents
 
+> **Note (TRON):** For TRON deployments, M2M now uses [Bank of AI's TRC-8004 contracts](https://github.com/BofAI/contracts). Selected improvements will be proposed upstream. EVM deployments in this repo remain active.
+
 Implementation of the ERC-8004 protocol for agent discovery and trust through reputation and validation.
 
 ### Contract Addresses


### PR DESCRIPTION
## Summary

Adds **TRON** (TRC-8004) deployed contract addresses for Mainnet and Shasta Testnet to the README. This is a non-EVM implementation of ERC-8004 using Solidity on the TRON Virtual Machine (TVM), which is ABI-compatible with the EVM reference contracts.

No code changes — documentation only.

## Contract Addresses

### TRON Mainnet

| Contract | Address |
|----------|---------|
| IdentityRegistry | [`THmfi8uJuUpTfUmYLDX7UD1KaE4P6HKgqA`](https://tronscan.org/#/contract/THmfi8uJuUpTfUmYLDX7UD1KaE4P6HKgqA) |
| ReputationRegistry | [`TV8KWmp8qcj55sjs1NSjVxmRmZP7CYzNxH`](https://tronscan.org/#/contract/TV8KWmp8qcj55sjs1NSjVxmRmZP7CYzNxH) |
| ValidationRegistry | [`TCoJA4BYXWZhp5eanCchMw67VA83tQ83n1`](https://tronscan.org/#/contract/TCoJA4BYXWZhp5eanCchMw67VA83tQ83n1) |
| IncidentRegistry | [`TJ26Pu24ar7Qdh9Bm6tbBVdtzCJkbxS5eR`](https://tronscan.org/#/contract/TJ26Pu24ar7Qdh9Bm6tbBVdtzCJkbxS5eR) |

### TRON Shasta (Testnet)

| Contract | Address |
|----------|---------|
| IdentityRegistry | [`TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7`](https://shasta.tronscan.org/#/contract/TFKNqk9bjwWp5uRiiGimqfLhVQB8jSxYi7) |
| ReputationRegistry | [`TRaYogyr2qc7WgsmuVF5Js39aCmoG7vZrA`](https://shasta.tronscan.org/#/contract/TRaYogyr2qc7WgsmuVF5Js39aCmoG7vZrA) |
| ValidationRegistry | [`TPgGWWyUdxNryUCN49TdT4b3F4WB3Edr16`](https://shasta.tronscan.org/#/contract/TPgGWWyUdxNryUCN49TdT4b3F4WB3Edr16) |
| IncidentRegistry | [`TPB59NFdypBpkJtWH7yE8XenKrdT1Q4g4s`](https://shasta.tronscan.org/#/contract/TPB59NFdypBpkJtWH7yE8XenKrdT1Q4g4s) |

## Implementation Details

TRC-8004 is a TRON-native implementation of ERC-8004 with full feature parity:

- **Same Solidity contracts** — TRON's TVM is ABI-compatible with EVM, so the same Solidity source compiles and deploys directly via TronBox
- **All four registries deployed** — Identity, Reputation, Validation, plus an additional Incident Registry for reporting and resolving agent incidents
- **Base58check addresses** — TRON uses base58check-encoded addresses (e.g., `THmfi8...`) instead of 0x hex, but the underlying contract logic is identical
- **v2 security hardening** — EIP-2 signature malleability protection, EIP-712 nonce replay protection, self-feedback prevention, string length limits, response thread caps

### Additional Registry: IncidentRegistry

TRC-8004 includes a 4th registry not in the base ERC-8004 spec:

- `reportIncident(agentId, category, description)` — report an agent incident
- `respondToIncident(incidentId, response)` — agent responds to incident
- `resolveIncident(incidentId, resolution)` — resolve with outcome

This extends the trust signal model with incident tracking and is fully optional.

## Proposed Changes

- Add **TRON Mainnet** contract addresses to `README.md` (alphabetically after Taiko)
- Add **TRON Shasta (Testnet)** contract addresses to `README.md`
- No code or spec changes

## Integration Tests

- **44 integration tests** verified on TRON Mainnet
- **332 unit tests** with 97.9% coverage on the backend API
- All contracts verified on TronScan

## Links

- TRON Mainnet Explorer: https://tronscan.org
- TRON Shasta Explorer: https://shasta.tronscan.org
- M2M TRC-8004 Registry: https://github.com/M2M-TRC8004-Registry