### PR TITLE
docs: Add ERC-8004 addresses for Flow EVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 - **IdentityRegistry**: [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](https://testnet.arcscan.app/address/0x8004A818BFB912233c491871b3d84c89A494BD9e)
 - **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://testnet.arcscan.app/address/0x8004B663056A597Dffe9eCcC1965A193B7388713)
 
+#### Flow EVM Mainnet
+- **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://evm.flowscan.io/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
+- **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://evm.flowscan.io/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)
+
+#### Flow EVM Testnet
+- **IdentityRegistry**: [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](https://evm-testnet.flowscan.io/address/0x8004A818BFB912233c491871b3d84c89A494BD9e)
+- **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://evm-testnet.flowscan.io/address/0x8004B663056A597Dffe9eCcC1965A193B7388713)
+
 More chains coming soon...
 
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -473,6 +473,24 @@ const config: HardhatUserConfig = {
           apiUrl: "https://testnet.arcscan.app/api",
         }
       }
+    },
+    747: {
+      name: "Flow EVM Mainnet",
+      blockExplorers: {
+        blockscout: {
+          url: "https://evm.flowscan.io",
+          apiUrl: "https://evm.flowscan.io/api",
+        }
+      }
+    },
+    545: {
+      name: "Flow EVM Testnet",
+      blockExplorers: {
+        blockscout: {
+          url: "https://evm-testnet.flowscan.io",
+          apiUrl: "https://evm-testnet.flowscan.io/api",
+        }
+      }
     }
   },
   solidity: {
@@ -793,6 +811,18 @@ const config: HardhatUserConfig = {
       url: process.env.ARC_TESTNET_RPC_URL || "https://rpc.testnet.arc.network",
       accounts: process.env.ARC_TESTNET_PRIVATE_KEY ? [process.env.ARC_TESTNET_PRIVATE_KEY] : [],
     },
+    flowTestnet: {
+      type: "http",
+      chainType: "l1",
+      url: process.env.FLOW_TESTNET_RPC_URL || "https://testnet.evm.nodes.onflow.org",
+      accounts: process.env.FLOW_TESTNET_PRIVATE_KEY ? [process.env.FLOW_TESTNET_PRIVATE_KEY] : [],
+    },
+    flowMainnet: {
+      type: "http",
+      chainType: "l1",
+      url: process.env.FLOW_MAINNET_RPC_URL || "https://mainnet.evm.nodes.onflow.org",
+      accounts: process.env.FLOW_MAINNET_PRIVATE_KEY ? [process.env.FLOW_MAINNET_PRIVATE_KEY] : [],
+    }
   },
 };
 

--- a/scripts/addresses.ts
+++ b/scripts/addresses.ts
@@ -27,6 +27,7 @@ export const MAINNET_CHAIN_IDS = [
   295,    // Hedera
   1187947933, // SKALE Base
   360,        // Shape
+  747,        // Flow EVM
 ];
 
 /**
@@ -58,6 +59,7 @@ export const TESTNET_CHAIN_IDS = [
   324705682, // SKALE Base Sepolia
   5042002,   // Arc Testnet
   11011,     // Shape Sepolia
+  545,       // Flow EVM
 ];
 
 /**


### PR DESCRIPTION
Deployed addresses for `ERC-8004` contracts on Flow EVM:

Flow EVM Mainnet:
- **IdentityRegistry**: [0x8004A169FB4a3325136EB29fA0ceB6D2e539a432](https://evm.flowscan.io/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
- **ReputationRegistry**: [0x8004BAa17C55a88189AE136b182e5fdA19dE9b63](https://evm.flowscan.io/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)

Flow EVM Testnet:
- **IdentityRegistry**: [0x8004A818BFB912233c491871b3d84c89A494BD9e](https://evm-testnet.flowscan.io/address/0x8004A818BFB912233c491871b3d84c89A494BD9e)
- **ReputationRegistry**: [0x8004B663056A597Dffe9eCcC1965A193B7388713](https://evm-testnet.flowscan.io/address/0x8004B663056A597Dffe9eCcC1965A193B7388713)

Nice work putting together the ERC-8004 and its reference implementation :clap: 

