### PR TITLE
feat: upgrade solidity version to use custom errors in require

### DIFF
--- a/contracts/ERC1967Proxy.sol
+++ b/contracts/ERC1967Proxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol" as OZProxy;
 

--- a/contracts/HardhatMinimalUUPS.sol
+++ b/contracts/HardhatMinimalUUPS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/contracts/IdentityRegistryUpgradeable.sol
+++ b/contracts/IdentityRegistryUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -14,6 +14,13 @@ contract IdentityRegistryUpgradeable is
     UUPSUpgradeable,
     EIP712Upgradeable
 {
+    error NotAuthorized();
+    error ReservedKey();
+    error BadWallet();
+    error Expired();
+    error DeadlineTooFar();
+    error InvalidWalletSignature();
+
     struct MetadataEntry {
         string metadataKey;
         bytes metadataValue;
@@ -86,7 +93,7 @@ contract IdentityRegistryUpgradeable is
         emit MetadataSet(agentId, "agentWallet", "agentWallet", abi.encodePacked(msg.sender));
 
         for (uint256 i; i < metadata.length; i++) {
-            require(keccak256(bytes(metadata[i].metadataKey)) != RESERVED_AGENT_WALLET_KEY_HASH, "reserved key");
+            require(keccak256(bytes(metadata[i].metadataKey)) != RESERVED_AGENT_WALLET_KEY_HASH, ReservedKey());
             $._metadata[agentId][metadata[i].metadataKey] = metadata[i].metadataValue;
             emit MetadataSet(agentId, metadata[i].metadataKey, metadata[i].metadataKey, metadata[i].metadataValue);
         }
@@ -100,12 +107,10 @@ contract IdentityRegistryUpgradeable is
     function setMetadata(uint256 agentId, string memory metadataKey, bytes memory metadataValue) external {
         address agentOwner = _ownerOf(agentId);
         require(
-            msg.sender == agentOwner ||
-            isApprovedForAll(agentOwner, msg.sender) ||
-            msg.sender == getApproved(agentId),
-            "Not authorized"
+            msg.sender == agentOwner || isApprovedForAll(agentOwner, msg.sender) || msg.sender == getApproved(agentId),
+            NotAuthorized()
         );
-        require(keccak256(bytes(metadataKey)) != RESERVED_AGENT_WALLET_KEY_HASH, "reserved key");
+        require(keccak256(bytes(metadataKey)) != RESERVED_AGENT_WALLET_KEY_HASH, ReservedKey());
         IdentityRegistryStorage storage $ = _getIdentityRegistryStorage();
         $._metadata[agentId][metadataKey] = metadataValue;
         emit MetadataSet(agentId, metadataKey, metadataKey, metadataValue);
@@ -114,10 +119,8 @@ contract IdentityRegistryUpgradeable is
     function setAgentURI(uint256 agentId, string calldata newURI) external {
         address owner = ownerOf(agentId);
         require(
-            msg.sender == owner ||
-            isApprovedForAll(owner, msg.sender) ||
-            msg.sender == getApproved(agentId),
-            "Not authorized"
+            msg.sender == owner || isApprovedForAll(owner, msg.sender) || msg.sender == getApproved(agentId),
+            NotAuthorized()
         );
         _setTokenURI(agentId, newURI);
         emit URIUpdated(agentId, newURI, msg.sender);
@@ -129,34 +132,26 @@ contract IdentityRegistryUpgradeable is
         return address(bytes20(walletData));
     }
 
-    function setAgentWallet(
-        uint256 agentId,
-        address newWallet,
-        uint256 deadline,
-        bytes calldata signature
-    ) external {
+    function setAgentWallet(uint256 agentId, address newWallet, uint256 deadline, bytes calldata signature) external {
         address owner = ownerOf(agentId);
         require(
-            msg.sender == owner ||
-            isApprovedForAll(owner, msg.sender) ||
-            msg.sender == getApproved(agentId),
-            "Not authorized"
+            msg.sender == owner || isApprovedForAll(owner, msg.sender) || msg.sender == getApproved(agentId),
+            NotAuthorized()
         );
-        require(newWallet != address(0), "bad wallet");
-        require(block.timestamp <= deadline, "expired");
-        require(deadline <= block.timestamp + MAX_DEADLINE_DELAY, "deadline too far");
+        require(newWallet != address(0), BadWallet());
+        require(block.timestamp <= deadline, Expired());
+        require(deadline <= block.timestamp + MAX_DEADLINE_DELAY, DeadlineTooFar());
 
         bytes32 structHash = keccak256(abi.encode(AGENT_WALLET_SET_TYPEHASH, agentId, newWallet, owner, deadline));
         bytes32 digest = _hashTypedDataV4(structHash);
 
         // Try ECDSA first (EOAs + EIP-7702 delegated EOAs)
-        (address recovered, ECDSA.RecoverError err, ) = ECDSA.tryRecover(digest, signature);
+        (address recovered, ECDSA.RecoverError err,) = ECDSA.tryRecover(digest, signature);
         if (err != ECDSA.RecoverError.NoError || recovered != newWallet) {
             // ECDSA failed, try ERC1271 (smart contract wallets)
-            (bool ok, bytes memory res) = newWallet.staticcall(
-                abi.encodeCall(IERC1271.isValidSignature, (digest, signature))
-            );
-            require(ok && res.length >= 32 && abi.decode(res, (bytes4)) == ERC1271_MAGICVALUE, "invalid wallet sig");
+            (bool ok, bytes memory res) =
+                newWallet.staticcall(abi.encodeCall(IERC1271.isValidSignature, (digest, signature)));
+            require(ok && res.length >= 32 && abi.decode(res, (bytes4)) == ERC1271_MAGICVALUE, InvalidWalletSignature());
         }
 
         IdentityRegistryStorage storage $ = _getIdentityRegistryStorage();
@@ -167,10 +162,8 @@ contract IdentityRegistryUpgradeable is
     function unsetAgentWallet(uint256 agentId) external {
         address owner = ownerOf(agentId);
         require(
-            msg.sender == owner ||
-            isApprovedForAll(owner, msg.sender) ||
-            msg.sender == getApproved(agentId),
-            "Not authorized"
+            msg.sender == owner || isApprovedForAll(owner, msg.sender) || msg.sender == getApproved(agentId),
+            NotAuthorized()
         );
 
         IdentityRegistryStorage storage $ = _getIdentityRegistryStorage();

--- a/contracts/MinimalUUPS.sol
+++ b/contracts/MinimalUUPS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/contracts/MinimalUUPSMainnet.sol
+++ b/contracts/MinimalUUPSMainnet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/contracts/ReputationRegistryUpgradeable.sol
+++ b/contracts/ReputationRegistryUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -9,6 +9,16 @@ interface IIdentityRegistry {
 }
 
 contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
+
+    error BadIdentity();
+    error TooManyDecimals();
+    error ValueTooLarge();
+    error SelfFeedbackNotAllowed();
+    error InvalidIndex();
+    error IndexOutOfBounds();
+    error AlreadyRevoked();
+    error EmptyURI();
+    error ClientAddressesRequired();
 
     int128 private constant MAX_ABS_VALUE = 1e38;
 
@@ -84,7 +94,7 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function initialize(address identityRegistry_) public reinitializer(2) onlyOwner {
-        require(identityRegistry_ != address(0), "bad identity");
+        require(identityRegistry_ != address(0), BadIdentity());
         _identityRegistry = identityRegistry_;
     }
 
@@ -102,12 +112,12 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
         string calldata feedbackURI,
         bytes32 feedbackHash
     ) external {
-        require(valueDecimals <= 18, "too many decimals");
-        require(value >= -MAX_ABS_VALUE && value <= MAX_ABS_VALUE, "value too large");
+        require(valueDecimals <= 18, TooManyDecimals());
+        require(value >= -MAX_ABS_VALUE && value <= MAX_ABS_VALUE, ValueTooLarge());
 
         // SECURITY: Prevent self-feedback from owner and operators
         // Also reverts with ERC721NonexistentToken if agent doesn't exist
-        require(!IIdentityRegistry(_identityRegistry).isAuthorizedOrOwner(msg.sender, agentId), "Self-feedback not allowed");
+        require(!IIdentityRegistry(_identityRegistry).isAuthorizedOrOwner(msg.sender, agentId), SelfFeedbackNotAllowed());
 
         ReputationRegistryStorage storage $ = _getReputationRegistryStorage();
 
@@ -133,10 +143,10 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function revokeFeedback(uint256 agentId, uint64 feedbackIndex) external {
-        require(feedbackIndex > 0, "index must be > 0");
+        require(feedbackIndex > 0, InvalidIndex());
         ReputationRegistryStorage storage $ = _getReputationRegistryStorage();
-        require(feedbackIndex <= $._lastIndex[agentId][msg.sender], "index out of bounds");
-        require(!$._feedback[agentId][msg.sender][feedbackIndex].isRevoked, "Already revoked");
+        require(feedbackIndex <= $._lastIndex[agentId][msg.sender], IndexOutOfBounds());
+        require(!$._feedback[agentId][msg.sender][feedbackIndex].isRevoked, AlreadyRevoked());
 
         $._feedback[agentId][msg.sender][feedbackIndex].isRevoked = true;
         emit FeedbackRevoked(agentId, msg.sender, feedbackIndex);
@@ -149,10 +159,10 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
         string calldata responseURI,
         bytes32 responseHash
     ) external {
-        require(feedbackIndex > 0, "index must be > 0");
-        require(bytes(responseURI).length > 0, "Empty URI");
+        require(feedbackIndex > 0, InvalidIndex());
+        require(bytes(responseURI).length > 0, EmptyURI());
         ReputationRegistryStorage storage $ = _getReputationRegistryStorage();
-        require(feedbackIndex <= $._lastIndex[agentId][clientAddress], "index out of bounds");
+        require(feedbackIndex <= $._lastIndex[agentId][clientAddress], IndexOutOfBounds());
 
         // Track new responder
         if (!$._responderExists[agentId][clientAddress][feedbackIndex][msg.sender]) {
@@ -177,8 +187,8 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
         returns (int128 value, uint8 valueDecimals, string memory tag1, string memory tag2, bool isRevoked)
     {
         ReputationRegistryStorage storage $ = _getReputationRegistryStorage();
-        require(feedbackIndex > 0, "index must be > 0");
-        require(feedbackIndex <= $._lastIndex[agentId][clientAddress], "index out of bounds");
+        require(feedbackIndex > 0, InvalidIndex());
+        require(feedbackIndex <= $._lastIndex[agentId][clientAddress], IndexOutOfBounds());
         Feedback storage f = $._feedback[agentId][clientAddress][feedbackIndex];
         return (f.value, f.valueDecimals, f.tag1, f.tag2, f.isRevoked);
     }
@@ -191,12 +201,7 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
     ) external view returns (uint64 count, int128 summaryValue, uint8 summaryValueDecimals) {
 
         ReputationRegistryStorage storage $ = _getReputationRegistryStorage();
-        address[] memory clientList;
-        if (clientAddresses.length > 0) {
-            clientList = clientAddresses;
-        } else {
-            revert("clientAddresses required");
-        }
+        require(clientAddresses.length > 0, ClientAddressesRequired());
 
         bytes32 emptyHash = keccak256(bytes(""));
         bytes32 tag1Hash = keccak256(bytes(tag1));
@@ -208,22 +213,20 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
         // Track frequency of each valueDecimals (0-18, anything >18 treated as 18)
         uint64[19] memory decimalCounts;
 
-        for (uint256 i; i < clientList.length; i++) {
-            uint64 lastIdx = $._lastIndex[agentId][clientList[i]];
+        for (uint256 i; i < clientAddresses.length; i++) {
+            uint64 lastIdx = $._lastIndex[agentId][clientAddresses[i]];
             for (uint64 j = 1; j <= lastIdx; j++) {
-                Feedback storage fb = $._feedback[agentId][clientList[i]][j];
+                Feedback storage fb = $._feedback[agentId][clientAddresses[i]][j];
                 if (fb.isRevoked) continue;
-                if (emptyHash != tag1Hash &&
-                    tag1Hash != keccak256(bytes(fb.tag1))) continue;
-                if (emptyHash != tag2Hash &&
-                    tag2Hash != keccak256(bytes(fb.tag2))) continue;
+                if (emptyHash != tag1Hash && tag1Hash != keccak256(bytes(fb.tag1))) continue;
+                if (emptyHash != tag2Hash && tag2Hash != keccak256(bytes(fb.tag2))) continue;
 
                 // Normalize to 18 decimals (WAD)
                 // `valueDecimals` is bounded to <= 18 on write; keep math signed.
                 int256 factor = int256(10 ** uint256(18 - fb.valueDecimals));
                 int256 normalized = fb.value * factor;
                 decimalCounts[fb.valueDecimals]++;
-
+                
                 sum += normalized;
                 count++;
             }
@@ -282,10 +285,8 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
             for (uint64 j = 1; j <= lastIdx; j++) {
                 Feedback storage fb = $._feedback[agentId][clientList[i]][j];
                 if (!includeRevoked && fb.isRevoked) continue;
-                if (emptyHash != tag1Hash &&
-                    tag1Hash != keccak256(bytes(fb.tag1))) continue;
-                if (emptyHash != tag2Hash &&
-                    tag2Hash != keccak256(bytes(fb.tag2))) continue;
+                if (emptyHash != tag1Hash && tag1Hash != keccak256(bytes(fb.tag1))) continue;
+                if (emptyHash != tag2Hash && tag2Hash != keccak256(bytes(fb.tag2))) continue;
                 totalCount++;
             }
         }
@@ -306,10 +307,8 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
             for (uint64 j = 1; j <= lastIdx; j++) {
                 Feedback storage fb = $._feedback[agentId][clientList[i]][j];
                 if (!includeRevoked && fb.isRevoked) continue;
-                if (emptyHash != tag1Hash &&
-                    tag1Hash != keccak256(bytes(fb.tag1))) continue;
-                if (emptyHash != tag2Hash &&
-                    tag2Hash != keccak256(bytes(fb.tag2))) continue;
+                if (emptyHash != tag1Hash && tag1Hash != keccak256(bytes(fb.tag1))) continue;
+                if (emptyHash != tag2Hash && tag2Hash != keccak256(bytes(fb.tag2))) continue;
 
                 clients[idx] = clientList[i];
                 feedbackIndexes[idx] = j;

--- a/contracts/SingletonFactory.sol
+++ b/contracts/SingletonFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.26;
 
 /**
  * @title Singleton Factory (EIP-2470)

--- a/contracts/ValidationRegistryUpgradeable.sol
+++ b/contracts/ValidationRegistryUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -11,6 +11,14 @@ interface IIdentityRegistry {
 }
 
 contract ValidationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
+    error BadIdentity();
+    error BadValidator();
+    error ValidationExists();
+    error NotAuthorized();
+    error UnknownRequest();
+    error NotValidator();
+    error ResponseOutOfRange();
+
     event ValidationRequest(
         address indexed validatorAddress,
         uint256 indexed agentId,
@@ -31,7 +39,7 @@ contract ValidationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
     struct ValidationStatus {
         address validatorAddress;
         uint256 agentId;
-        uint8 response;       // 0..100
+        uint8 response; // 0..100
         bytes32 responseHash;
         string tag;
         uint256 lastUpdate;
@@ -67,7 +75,7 @@ contract ValidationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
     }
 
     function initialize(address identityRegistry_) public reinitializer(2) onlyOwner {
-        require(identityRegistry_ != address(0), "bad identity");
+        require(identityRegistry_ != address(0), BadIdentity());
         _identityRegistry = identityRegistry_;
     }
 
@@ -82,17 +90,16 @@ contract ValidationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
         bytes32 requestHash
     ) external {
         ValidationRegistryStorage storage $ = _getValidationRegistryStorage();
-        require(validatorAddress != address(0), "bad validator");
-        require($.validations[requestHash].validatorAddress == address(0), "exists");
+        require(validatorAddress != address(0), BadValidator());
+        require($.validations[requestHash].validatorAddress == address(0), ValidationExists());
 
         // Check permission: caller must be owner or approved operator
         IIdentityRegistry registry = IIdentityRegistry(_identityRegistry);
         address owner = registry.ownerOf(agentId);
         require(
-            msg.sender == owner ||
-            registry.isApprovedForAll(owner, msg.sender) ||
-            registry.getApproved(agentId) == msg.sender,
-            "Not authorized"
+            msg.sender == owner || registry.isApprovedForAll(owner, msg.sender)
+                || registry.getApproved(agentId) == msg.sender,
+            NotAuthorized()
         );
 
         $.validations[requestHash] = ValidationStatus({
@@ -121,9 +128,9 @@ contract ValidationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
     ) external {
         ValidationRegistryStorage storage $ = _getValidationRegistryStorage();
         ValidationStatus storage s = $.validations[requestHash];
-        require(s.validatorAddress != address(0), "unknown");
-        require(msg.sender == s.validatorAddress, "not validator");
-        require(response <= 100, "resp>100");
+        require(s.validatorAddress != address(0), UnknownRequest());
+        require(msg.sender == s.validatorAddress, NotValidator());
+        require(response <= 100, ResponseOutOfRange());
         s.response = response;
         s.responseHash = responseHash;
         s.tag = tag;
@@ -135,22 +142,28 @@ contract ValidationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
     function getValidationStatus(bytes32 requestHash)
         external
         view
-        returns (address validatorAddress, uint256 agentId, uint8 response, bytes32 responseHash, string memory tag, uint256 lastUpdate)
+        returns (
+            address validatorAddress,
+            uint256 agentId,
+            uint8 response,
+            bytes32 responseHash,
+            string memory tag,
+            uint256 lastUpdate
+        )
     {
         ValidationRegistryStorage storage $ = _getValidationRegistryStorage();
         ValidationStatus memory s = $.validations[requestHash];
-        require(s.validatorAddress != address(0), "unknown");
+        require(s.validatorAddress != address(0), UnknownRequest());
         return (s.validatorAddress, s.agentId, s.response, s.responseHash, s.tag, s.lastUpdate);
     }
 
-    function getSummary(
-        uint256 agentId,
-        address[] calldata validatorAddresses,
-        string calldata tag
-    ) external view returns (uint64 count, uint8 avgResponse) {
+    function getSummary(uint256 agentId, address[] calldata validatorAddresses, string calldata tag)
+        external
+        view
+        returns (uint64 count, uint8 avgResponse)
+    {
         ValidationRegistryStorage storage $ = _getValidationRegistryStorage();
         uint256 totalResponse;
-
         bytes32[] storage requestHashes = $._agentValidations[agentId];
 
         for (uint256 i; i < requestHashes.length; i++) {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -478,7 +478,7 @@ const config: HardhatUserConfig = {
   solidity: {
     profiles: {
       default: {
-        version: "0.8.24",
+        version: "0.8.26",
         settings: {
           evmVersion: "shanghai",
           optimizer: {
@@ -490,7 +490,7 @@ const config: HardhatUserConfig = {
         },
       },
       production: {
-        version: "0.8.24",
+        version: "0.8.26",
         settings: {
           evmVersion: "shanghai",
           optimizer: {
@@ -514,13 +514,13 @@ const config: HardhatUserConfig = {
     sepolia: {
       type: "http",
       chainType: "l1",
-      url: process.env.SEPOLIA_RPC_URL || "",
+      url: process.env.SEPOLIA_RPC_URL || "https://rpc.sepolia.org",
       accounts: process.env.SEPOLIA_PRIVATE_KEY ? [process.env.SEPOLIA_PRIVATE_KEY] : [],
     },
     mainnet: {
       type: "http",
       chainType: "l1",
-      url: process.env.MAINNET_RPC_URL || "",
+      url: process.env.MAINNET_RPC_URL || "https://eth.llamarpc.com",
       accounts: process.env.MAINNET_PRIVATE_KEY ? [process.env.MAINNET_PRIVATE_KEY] : [],
     },
     baseSepolia: {

--- a/test/core.ts
+++ b/test/core.ts
@@ -292,7 +292,7 @@ describe("ERC8004 Registries", async function () {
 
       await assert.rejects(
         identityRegistry.write.setMetadata([agentId, "agentWallet", toHex("0xdeadbeef")]),
-        /reserved key/i
+        /ReservedKey|reserved key/i
       );
     });
 
@@ -305,7 +305,7 @@ describe("ERC8004 Registries", async function () {
 
       await assert.rejects(
         identityRegistry.write.register(["ipfs://agent", metadata]),
-        /reserved key/i
+        /ReservedKey|reserved key/i
       );
     });
 
@@ -401,7 +401,7 @@ describe("ERC8004 Registries", async function () {
           [agentId, newWalletSigner.account.address, deadline, signature],
           { account: owner.account }
         ),
-        /invalid wallet sig/i
+        /InvalidWalletSignature|invalid wallet sig/i
       );
     });
 
@@ -446,7 +446,7 @@ describe("ERC8004 Registries", async function () {
           [agentId, newWalletSigner.account.address, deadline, signature],
           { account: owner.account }
         ),
-        /expired/i
+        /Expired|expired/i
       );
     });
 
@@ -491,7 +491,7 @@ describe("ERC8004 Registries", async function () {
           [agentId, newWalletSigner.account.address, deadline, signature],
           { account: owner.account }
         ),
-        /deadline too far/i
+        /DeadlineTooFar|deadline too far/i
       );
     });
 
@@ -537,7 +537,7 @@ describe("ERC8004 Registries", async function () {
           [agentId, newWalletSigner.account.address, deadline, signature],
           { account: attacker.account }
         ),
-        /Not authorized/i
+        /NotAuthorized|Not authorized/i
       );
     });
 
@@ -924,7 +924,7 @@ describe("ERC8004 Registries", async function () {
             keccak256(toHex("content")),
           ], { account: agentOwner.account });
         },
-        /Self-feedback not allowed|revert/
+        /SelfFeedbackNotAllowed|Self-feedback not allowed|revert/
       );
     });
 
@@ -1483,7 +1483,7 @@ describe("ERC8004 Registries", async function () {
             agentId, client.account.address, 2n
           ]);
         },
-        /index out of bounds|revert/
+        /IndexOutOfBounds|index out of bounds|revert/
       );
     });
 

--- a/test/local.ts
+++ b/test/local.ts
@@ -650,7 +650,7 @@ describe("ERC8004 Registries", async function () {
             keccak256(toHex("content")),
           ], { account: agentOwner.account });
         },
-        /Self-feedback not allowed|revert/
+        /SelfFeedbackNotAllowed|Self-feedback not allowed|revert/
       );
     });
 
@@ -1209,7 +1209,7 @@ describe("ERC8004 Registries", async function () {
             agentId, client.account.address, 2n
           ]);
         },
-        /index out of bounds|revert/
+        /IndexOutOfBounds|index out of bounds|revert/
       );
     });
 

--- a/test/upgradeable.ts
+++ b/test/upgradeable.ts
@@ -319,7 +319,7 @@ describe("ERC8004 Upgradeable Registries", async function () {
 
         await assert.rejects(
           minimalProxy.write.upgradeToAndCall([reputationImpl.address, reinitCalldata]),
-          /bad identity/,
+          /BadIdentity|bad identity/,
           "Should reject zero address for identityRegistry"
         );
       });


### PR DESCRIPTION
Optimize the smart contracts to use custom errors in `require` for:
- better error handling on the consumer side
- better gas usage over error messages in `string`

Enabled by upgrading the contracts' solidity version to [0.8.26](https://www.soliditylang.org/blog/2024/05/21/solidity-0.8.26-release-announcement/).

Also added the default RPC for mainnet and sepolia for handling cases when respective RPC variable is not set in `.env `, hopefully this change doesn't sound opinionated.

Already ran `npm test` to make sure all tests work successfully.