### PR TITLE
doc: add billions networks implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 - **IdentityRegistry**: [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](https://testnet.arcscan.app/address/0x8004A818BFB912233c491871b3d84c89A494BD9e)
 - **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://testnet.arcscan.app/address/0x8004B663056A597Dffe9eCcC1965A193B7388713)
 
+#### Billions Mainnet
+- **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://explorer.billions.network/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
+- **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://explorer.billions.network/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)
+
+#### Billions Testnet
+- **IdentityRegistry**: [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](https://explorer-testnet.billions.network/address/0x8004A818BFB912233c491871b3d84c89A494BD9e)
+- **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://explorer-testnet.billions.network/address/0x8004B663056A597Dffe9eCcC1965A193B7388713)
+
 More chains coming soon...
 
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -473,6 +473,24 @@ const config: HardhatUserConfig = {
           apiUrl: "https://testnet.arcscan.app/api",
         }
       }
+    },
+    6913: {
+      name: "Billions Testnet",
+      blockExplorers: {
+        blockscout: {
+          url: "https://explorer-testnet.billions.network",
+          apiUrl: "https://explorer-testnet.billions.network/api/",
+        },
+      },
+    },
+    45056: {
+      name: "Billions",
+      blockExplorers: {
+        blockscout: {
+          url: "https://explorer.billions.network",
+          apiUrl: "https://explorer.billions.network/api/",
+        },
+      },
     }
   },
   solidity: {
@@ -792,6 +810,18 @@ const config: HardhatUserConfig = {
       chainType: "l1",
       url: process.env.ARC_TESTNET_RPC_URL || "https://rpc.testnet.arc.network",
       accounts: process.env.ARC_TESTNET_PRIVATE_KEY ? [process.env.ARC_TESTNET_PRIVATE_KEY] : [],
+    },
+    billionsTestnet: {
+      type: "http",
+      chainType: "l1",
+      url: process.env.BILLIONS_TESTNET_RPC_URL || "https://rpc-testnet.billions.network",
+      accounts: process.env.BILLIONS_TESTNET_PRIVATE_KEY ? [process.env.BILLIONS_TESTNET_PRIVATE_KEY] : [],
+    },
+    billions: {
+      type: "http",
+      chainType: "l1",
+      url: process.env.BILLIONS_RPC_URL || "https://rpc-mainnet.billions.network",
+      accounts: process.env.BILLIONS_PRIVATE_KEY ? [process.env.BILLIONS_PRIVATE_KEY] : [],
     },
   },
 };

--- a/scripts/addresses.ts
+++ b/scripts/addresses.ts
@@ -27,6 +27,7 @@ export const MAINNET_CHAIN_IDS = [
   295,    // Hedera
   1187947933, // SKALE Base
   360,        // Shape
+  45056,  // Billions
 ];
 
 /**
@@ -58,6 +59,7 @@ export const TESTNET_CHAIN_IDS = [
   324705682, // SKALE Base Sepolia
   5042002,   // Arc Testnet
   11011,     // Shape Sepolia
+  6913,     // Billions Testnet
 ];
 
 /**


### PR DESCRIPTION
## Summary

As a member of the protocol team of **Billions Network**, we are proposing an update to the ERC-8004 addresses documentation to include the official ERC-8004 registry deployments on **Billions Testnet** and **Billions Mainnet**.

## Networks & Contract Addresses

### Billions Mainnet

* **IdentityRegistry:** `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`
* **ReputationRegistry:** `0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`

### Billions Testnet

* **IdentityRegistry:** `0x8004A818BFB912233c491871b3d84c89A494BD9e`
* **ReputationRegistry:** `0x8004B663056A597Dffe9eCcC1965A193B7388713`

## Proposed Changes

* Add **Billions Mainnet** contract addresses to `README.md`
* Add **Billions Testnet** contract addresses to `README.md`
* Add networks configuration and blockscout contracts verification to hardhat.config.ts
* Add addresses to scripts

## Motivation

Adding Billions networks addresses will enable agent explorers to include Billions networks to their supported networks to discover agents created in our networks as part of the Billions Network identity ecosystem, and keeps the identity registry addresses list aligned with updated deployment networks.
