### PR TITLE
feat: add 0G network contract addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 - **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://blockscout.injective.network/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
 - **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://blockscout.injective.network/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)
 
+#### 0G Mainnet
+- **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://chainscan.0g.ai/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
+- **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://chainscan.0g.ai/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)
+
 #### Injective Testnet
 - **IdentityRegistry**: [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](https://testnet.blockscout.injective.network/address/0x8004A818BFB912233c491871b3d84c89A494BD9e)
 - **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://testnet.blockscout.injective.network/address/0x8004B663056A597Dffe9eCcC1965A193B7388713)

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 - **IdentityRegistry**: [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](https://testnet.blockscout.injective.network/address/0x8004A818BFB912233c491871b3d84c89A494BD9e)
 - **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://testnet.blockscout.injective.network/address/0x8004B663056A597Dffe9eCcC1965A193B7388713)
 
+#### 0G Galileo Testnet
+- **IdentityRegistry**: [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](https://chainscan-galileo.0g.ai/address/0x8004A818BFB912233c491871b3d84c89A494BD9e)
+- **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://chainscan-galileo.0g.ai/address/0x8004B663056A597Dffe9eCcC1965A193B7388713)
+
 
 More chains coming soon...
 


### PR DESCRIPTION
## Summary

Adds 0G mainnet to the ERC-8004 contract address registry.

The standard ERC-8004 production contracts have been deployed on 0G mainnet at the canonical vanity addresses:

- **IdentityRegistry**: `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`
- **ReputationRegistry**: `0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`

**Chain details:**
- Chain ID: `16661`
- RPC: `https://evmrpc.0g.ai`
- Explorer: https://chainscan.0g.ai (Blockscout)

**On-chain verification:**
- IdentityRegistry: https://chainscan.0g.ai/address/0x8004a169fb4a3325136eb29fa0ceb6d2e539a432
- ReputationRegistry: https://chainscan.0g.ai/address/0x8004baa17c55a88189ae136b182e5fda19de9b63

## Changes

- `README.md`: add 0G mainnet entry to the Contract Addresses section