### PR TITLE
fix: block contract owners from self-feedback in giveFeedback()

### DIFF
--- a/contracts/ReputationRegistryUpgradeable.sol
+++ b/contracts/ReputationRegistryUpgradeable.sol
@@ -8,6 +8,10 @@ interface IIdentityRegistry {
     function isAuthorizedOrOwner(address spender, uint256 agentId) external view returns (bool);
 }
 
+interface IOwnable{
+    function owner() external view returns(address);
+}
+
 contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
 
     int128 private constant MAX_ABS_VALUE = 1e38;
@@ -108,6 +112,20 @@ contract ReputationRegistryUpgradeable is OwnableUpgradeable, UUPSUpgradeable {
         // SECURITY: Prevent self-feedback from owner and operators
         // Also reverts with ERC721NonexistentToken if agent doesn't exist
         require(!IIdentityRegistry(_identityRegistry).isAuthorizedOrOwner(msg.sender, agentId), "Self-feedback not allowed");
+
+        // SECURITY: transitive check for smart account owners
+        if (msg.sender.code.length>0){
+            try IOwnable(msg.sender).owner() returns (address contractOwner){
+
+                if(contractOwner != address(0)){
+                            require(!IIdentityRegistry(_identityRegistry).isAuthorizedOrOwner(contractOwner, agentId), "Self-feedback not allowed");
+
+                }
+
+            }
+
+            catch{}
+        }
 
         ReputationRegistryStorage storage $ = _getReputationRegistryStorage();
 


### PR DESCRIPTION
## fix: block Ownable contract owners from self-feedback in `giveFeedback()`

### Issue

The self-feedback guard in `giveFeedback()` checks `msg.sender` against the agent's owner
and operators. In a scenario where an agent owner routes a call through an `Ownable` contract
— such as an ERC-4337 smart account wallet — `msg.sender` resolves to the contract address
rather than the human who controls it. Since the contract itself is not registered as an agent
owner or operator, the guard passes.

### Fix

Add a transitive ownership check using a minimal `IOwnable` interface. If `msg.sender` is a
contract, resolve its `owner()` and apply the same guard against that address:

```solidity
if (msg.sender.code.length > 0) {
    try IOwnable(msg.sender).owner() returns (address contractOwner) {
        if (contractOwner != address(0)) {
            require(
                !IIdentityRegistry(_identityRegistry).isAuthorizedOrOwner(contractOwner, agentId),
                "Self-feedback not allowed"
            );
        }
    } catch {}
}
```

The `try/catch` ensures contracts that don't implement `owner()` are unaffected.
The `address(0)` guard handles contracts that have renounced ownership.
