### PR TITLE
Add XDC Network (50) and XDC Apothem testnet (51)

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -473,6 +473,24 @@ const config: HardhatUserConfig = {
           apiUrl: "https://testnet.arcscan.app/api",
         }
       }
+    },
+    50: {
+      name: "XDC Network",
+      blockExplorers: {
+        etherscan: {
+          url: "https://xdcscan.com",
+          apiUrl: "https://api.etherscan.io/v2/api",
+        }
+      }
+    },
+    51: {
+      name: "XDC Apothem Testnet",
+      blockExplorers: {
+        etherscan: {
+          url: "https://testnet.xdcscan.com",
+          apiUrl: "https://api.etherscan.io/v2/api",
+        }
+      }
     }
   },
   solidity: {
@@ -792,6 +810,18 @@ const config: HardhatUserConfig = {
       chainType: "l1",
       url: process.env.ARC_TESTNET_RPC_URL || "https://rpc.testnet.arc.network",
       accounts: process.env.ARC_TESTNET_PRIVATE_KEY ? [process.env.ARC_TESTNET_PRIVATE_KEY] : [],
+    },
+    xdc: {
+      type: "http",
+      chainType: "l1",
+      url: process.env.XDC_RPC_URL || "https://rpc.xdc.org",
+      accounts: process.env.XDC_PRIVATE_KEY ? [process.env.XDC_PRIVATE_KEY] : [],
+    },
+    xdcApothem: {
+      type: "http",
+      chainType: "l1",
+      url: process.env.XDC_APOTHEM_RPC_URL || "https://rpc.apothem.network",
+      accounts: process.env.XDC_APOTHEM_PRIVATE_KEY ? [process.env.XDC_APOTHEM_PRIVATE_KEY] : [],
     },
   },
 };

--- a/scripts/addresses.ts
+++ b/scripts/addresses.ts
@@ -27,6 +27,7 @@ export const MAINNET_CHAIN_IDS = [
   295,    // Hedera
   1187947933, // SKALE Base
   360,        // Shape
+  50,         // XDC Network
 ];
 
 /**
@@ -58,6 +59,7 @@ export const TESTNET_CHAIN_IDS = [
   324705682, // SKALE Base Sepolia
   5042002,   // Arc Testnet
   11011,     // Shape Sepolia
+  51,        // XDC Apothem Testnet
 ];
 
 /**


### PR DESCRIPTION
## Summary

Adds **XDC Network** mainnet (chainId `50`) and **XDC Apothem** testnet (chainId `51`) to the deterministic deployment setup. XDC slots into the existing model with **no special-casing** — same Safe Singleton Factory, same bytecode/salts, same Etherscan-V2 verification path as every other chain.

## Changes

- **`hardhat.config.ts`**
  - `networks`: `xdc` (50) and `xdcApothem` (51), `chainType: "l1"`, RPC defaults `https://rpc.xdc.org` / `https://rpc.apothem.network`, keys via `XDC_PRIVATE_KEY` / `XDC_APOTHEM_PRIVATE_KEY`.
  - `chainDescriptors`: entries `50` (explorer `https://xdcscan.com`) and `51` (explorer `https://testnet.xdcscan.com`), both using `apiUrl: https://api.etherscan.io/v2/api`.
- **`scripts/addresses.ts`**: `50` added to `MAINNET_CHAIN_IDS`, `51` added to `TESTNET_CHAIN_IDS`.

No `scripts/custom-chains.ts` entry needed — viem already ships `xdc` (50) and `xdcTestnet` (51).

## Why XDC works out of the box

| Dependency | Status on XDC |
|---|---|
| Safe Singleton Factory @ `0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7` | ✅ already live on both 50 and 51 (canonical Safe deployer `0xE1CB…BC37`); verified on-chain via `eth_getCode` |
| `shanghai` / PUSH0 bytecode | ✅ XDC implements EIP-3855 — recompiled bytecode reproduces the canonical `0x8004…` addresses byte-for-byte (see proof below) |
| Block explorer verification | ✅ both chains are on the **Etherscan V2 unified API** (`api.etherscan.io/v2/api`, chainlist `status: 1`) — the existing `ETHERSCAN_API_KEY` covers XDC, no custom endpoint |

### Deterministic address proof

Recomputing `getCreate2Address(factory, salt, keccak(initcode))` from freshly compiled artifacts (solc 0.8.24, evm target `shanghai`, viaIR, runs 200) reproduces the canonical proxy addresses for both chain types:

- chain 51 (testnet, `MinimalUUPS`) → `0x8004A818…`, `0x8004B663…`, `0x8004Cb1B…` ✅
- chain 50 (mainnet, `MinimalUUPSMainnet`) → `0x8004A169…`, `0x8004BAa1…`, `0x8004Cc84…` ✅ (also confirmed live on Ethereum + Base mainnets)

## Deployed & validated on-chain

Ran the standard flow (`deploy-vanity.ts`) on both networks — the Safe factory is already present, so `deploy-create2-factory.ts` was not needed.

### XDC Apothem testnet (51)
| Contract | Address |
|---|---|
| IdentityRegistry (proxy) | [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](https://testnet.xdcscan.com/address/0x8004A818BFB912233c491871b3d84c89A494BD9e) |
| ReputationRegistry (proxy) | [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://testnet.xdcscan.com/address/0x8004B663056A597Dffe9eCcC1965A193B7388713) |
| ValidationRegistry (proxy) | [`0x8004Cb1BF31DAf7788923b405b754f57acEB4272`](https://testnet.xdcscan.com/address/0x8004Cb1BF31DAf7788923b405b754f57acEB4272) |

### XDC Network mainnet (50)
| Contract | Address |
|---|---|
| IdentityRegistry (proxy) | [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://xdcscan.com/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432) |
| ReputationRegistry (proxy) | [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://xdcscan.com/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63) |
| ValidationRegistry (proxy) | [`0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58`](https://xdcscan.com/address/0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58) |

Implementations (identical on both chains): IdentityRegistry `0x7274e874CA62410a93Bd8bf61c69d8045E399c02`, ReputationRegistry `0xEe43505b156f7FbC9c0b2b60E3c3c33eaFe6ea4e`, ValidationRegistry `0x1B325b4035d264FE04f40a632B6798771127C79a`.

**On-chain validation (both networks, all ✅):** bytecode present at all 7 addresses · each proxy's ERC-1967 implementation slot → MinimalUUPS placeholder · all proxies owner-locked to `0x547289319C3e6aedB179C0b8e8aF0B5ACd062603` · cross-registry wiring correct (`_identityRegistry` slot0: Reputation/Validation → Identity, Identity → `0x0`) · `version()` reverts pre-upgrade (proxies still on placeholder). As on any fresh chain, the proxies await the owner's UUPS upgrade to the real implementations.

## How to reproduce

```bash
npm install --legacy-peer-deps   # see note below
npx hardhat run scripts/deploy-vanity.ts --network xdcApothem   # or --network xdc
# then the owner runs generate-triple-presigned-upgrade.ts + upgrade-vanity-presigned.ts + verify-vanity.ts
```

## Note for maintainers

The repo currently requires `npm install --legacy-peer-deps`: `@okxweb3/hardhat-explorer-verify` declares a peer dep of `hardhat@^2`, which conflicts with this Hardhat 3 project. Not changed in this PR, just flagging.
