### PR TITLE
Add HyperEVM (999) and HyperEVM Testnet (998)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 - **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://explorer.goat.network/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
 - **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://explorer.goat.network/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)
 
+#### HyperEVM Mainnet
+- **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://hyperevmscan.io/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
+- **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://hyperevmscan.io/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)
+
 #### Linea Mainnet
 - **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://lineascan.build/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
 - **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://lineascan.build/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Implementation of the ERC-8004 protocol for agent discovery and trust through re
 - **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://hyperevmscan.io/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
 - **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://hyperevmscan.io/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)
 
+#### HyperEVM Testnet
+- **IdentityRegistry**: [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](https://explore-testnet.hyperpc.app/address/0x8004A818BFB912233c491871b3d84c89A494BD9e)
+- **ReputationRegistry**: [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://explore-testnet.hyperpc.app/address/0x8004B663056A597Dffe9eCcC1965A193B7388713)
+
 #### Linea Mainnet
 - **IdentityRegistry**: [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://lineascan.build/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432)
 - **ReputationRegistry**: [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://lineascan.build/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63)

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -815,13 +815,13 @@ const config: HardhatUserConfig = {
       type: "http",
       chainType: "l1",
       url: process.env.HYPEREVM_RPC_URL || "https://rpc.hyperliquid.xyz/evm",
-      accounts: process.env.DEPLOYER_PK ? [process.env.DEPLOYER_PK] : [],
+      accounts: process.env.HYPEREVM_PRIVATE_KEY ? [process.env.HYPEREVM_PRIVATE_KEY] : [],
     },
     hyperevmTestnet: {
       type: "http",
       chainType: "l1",
       url: process.env.HYPEREVM_TESTNET_RPC_URL || "https://rpc.hyperliquid-testnet.xyz/evm",
-      accounts: process.env.DEPLOYER_PK ? [process.env.DEPLOYER_PK] : [],
+      accounts: process.env.HYPEREVM_TESTNET_PRIVATE_KEY ? [process.env.HYPEREVM_TESTNET_PRIVATE_KEY] : [],
     },
   },
 };

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -473,6 +473,24 @@ const config: HardhatUserConfig = {
           apiUrl: "https://testnet.arcscan.app/api",
         }
       }
+    },
+    999: {
+      name: "HyperEVM",
+      blockExplorers: {
+        etherscan: {
+          url: "https://hyperevmscan.io",
+          apiUrl: "https://api.etherscan.io/v2/api",
+        }
+      }
+    },
+    998: {
+      name: "HyperEVM Testnet",
+      blockExplorers: {
+        blockscout: {
+          url: "https://explore-testnet.hyperpc.app",
+          apiUrl: "https://explore-testnet.hyperpc.app/api",
+        }
+      }
     }
   },
   solidity: {
@@ -514,13 +532,13 @@ const config: HardhatUserConfig = {
     sepolia: {
       type: "http",
       chainType: "l1",
-      url: process.env.SEPOLIA_RPC_URL || "",
+      url: process.env.SEPOLIA_RPC_URL || "https://ethereum-sepolia-rpc.publicnode.com",
       accounts: process.env.SEPOLIA_PRIVATE_KEY ? [process.env.SEPOLIA_PRIVATE_KEY] : [],
     },
     mainnet: {
       type: "http",
       chainType: "l1",
-      url: process.env.MAINNET_RPC_URL || "",
+      url: process.env.MAINNET_RPC_URL || "https://ethereum-rpc.publicnode.com",
       accounts: process.env.MAINNET_PRIVATE_KEY ? [process.env.MAINNET_PRIVATE_KEY] : [],
     },
     baseSepolia: {
@@ -792,6 +810,18 @@ const config: HardhatUserConfig = {
       chainType: "l1",
       url: process.env.ARC_TESTNET_RPC_URL || "https://rpc.testnet.arc.network",
       accounts: process.env.ARC_TESTNET_PRIVATE_KEY ? [process.env.ARC_TESTNET_PRIVATE_KEY] : [],
+    },
+    hyperevm: {
+      type: "http",
+      chainType: "l1",
+      url: process.env.HYPEREVM_RPC_URL || "https://rpc.hyperliquid.xyz/evm",
+      accounts: process.env.DEPLOYER_PK ? [process.env.DEPLOYER_PK] : [],
+    },
+    hyperevmTestnet: {
+      type: "http",
+      chainType: "l1",
+      url: process.env.HYPEREVM_TESTNET_RPC_URL || "https://rpc.hyperliquid-testnet.xyz/evm",
+      accounts: process.env.DEPLOYER_PK ? [process.env.DEPLOYER_PK] : [],
     },
   },
 };

--- a/scripts/addresses.ts
+++ b/scripts/addresses.ts
@@ -27,6 +27,7 @@ export const MAINNET_CHAIN_IDS = [
   295,    // Hedera
   1187947933, // SKALE Base
   360,        // Shape
+  999,        // HyperEVM
 ];
 
 /**
@@ -58,6 +59,7 @@ export const TESTNET_CHAIN_IDS = [
   324705682, // SKALE Base Sepolia
   5042002,   // Arc Testnet
   11011,     // Shape Sepolia
+  998,       // HyperEVM Testnet
 ];
 
 /**


### PR DESCRIPTION
## Summary

Adds **HyperEVM** mainnet (chainId `999`) and **HyperEVM Testnet** (chainId `998`) to the deterministic deployment setup. HyperEVM slots into the existing model with **no special-casing** — same Safe Singleton Factory, same bytecode/salts, same vanity `0x8004…` addresses as every other chain. Two chain-specific notes: the testnet explorer is Blockscout (mainnet is Etherscan V2), and large-contract deploys require HyperEVM's "big blocks" (see below).

## Changes

- **`hardhat.config.ts`**
  - `networks`: `hyperevm` (999) and `hyperevmTestnet` (998), `chainType: "l1"`, RPC defaults `https://rpc.hyperliquid.xyz/evm` / `https://rpc.hyperliquid-testnet.xyz/evm`, keys via `HYPEREVM_PRIVATE_KEY` / `HYPEREVM_TESTNET_PRIVATE_KEY`.
  - `chainDescriptors`: entry `999` (explorer `https://hyperevmscan.io`, `apiUrl: https://api.etherscan.io/v2/api`) and entry `998` (Blockscout explorer `https://explore-testnet.hyperpc.app`, `apiUrl: https://explore-testnet.hyperpc.app/api`).
- **`scripts/addresses.ts`**: `999` added to `MAINNET_CHAIN_IDS`, `998` added to `TESTNET_CHAIN_IDS`.

No `scripts/custom-chains.ts` entry needed — the Hardhat network config (chainId + RPC) is sufficient; `deploy-vanity.ts`'s non-custom path connects via `hre.network.connect()` (verified reaching chainId `999`/`998`).

## Why HyperEVM works out of the box

| Dependency | Status on HyperEVM |
|---|---|
| Safe Singleton Factory @ `0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7` | ✅ already live on both 999 and 998; confirmed on-chain via `eth_getCode` and by `deploy-vanity.ts` ("Factory found") |
| `shanghai` / PUSH0 bytecode | ✅ HyperEVM implements EIP-3855 — recompiled bytecode reproduces the canonical `0x8004…` addresses byte-for-byte (the deployed proxies match Ethereum + Base mainnets exactly) |
| Block explorer verification | ✅ **mainnet (999)** is on the Etherscan V2 unified API (`api.etherscan.io/v2/api`, chainlist `status: 1`) — the existing `ETHERSCAN_API_KEY` covers it. **Testnet (998)** is **Blockscout** (`explore-testnet.hyperpc.app/api`) — a `chainDescriptors` `blockscout` entry, no key required |

**One chain-specific caveat:** HyperEVM uses a dual-block architecture (small ~1s / ~3M gas, big ~1min / 30M gas). The `IdentityRegistry` implementation is ~14.5 KB (~3.4M gas to deploy), which exceeds the small-block limit, so the deployer address must enable **big blocks** first (`evmUserModify { usingBigBlocks: true }`). This is a submission-time flag on the deployer, not a change to the repo or the bytecode.

### Deterministic address proof

Recomputing `getCreate2Address(factory, salt, keccak(initcode))` from freshly compiled artifacts (solc 0.8.24, evm target `shanghai`, viaIR, runs 200) reproduces the canonical proxy addresses for both chain types:

- chain 998 (testnet, `MinimalUUPS`) → `0x8004A818…`, `0x8004B663…`, `0x8004Cb1B…` ✅
- chain 999 (mainnet, `MinimalUUPSMainnet`) → `0x8004A169…`, `0x8004BAa1…`, `0x8004Cc84…` ✅ (also confirmed live on Ethereum + Base mainnets)

## Deployed & validated on-chain

Ran the standard flow (`deploy-vanity.ts`) on both networks — the Safe factory is already present, so `deploy-create2-factory.ts` was not needed.

### HyperEVM Testnet (998)
| Contract | Address |
|---|---|
| IdentityRegistry (proxy) | [`0x8004A818BFB912233c491871b3d84c89A494BD9e`](https://explore-testnet.hyperpc.app/address/0x8004A818BFB912233c491871b3d84c89A494BD9e) |
| ReputationRegistry (proxy) | [`0x8004B663056A597Dffe9eCcC1965A193B7388713`](https://explore-testnet.hyperpc.app/address/0x8004B663056A597Dffe9eCcC1965A193B7388713) |
| ValidationRegistry (proxy) | [`0x8004Cb1BF31DAf7788923b405b754f57acEB4272`](https://explore-testnet.hyperpc.app/address/0x8004Cb1BF31DAf7788923b405b754f57acEB4272) |

### HyperEVM Mainnet (999)
| Contract | Address |
|---|---|
| IdentityRegistry (proxy) | [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://hyperevmscan.io/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432) |
| ReputationRegistry (proxy) | [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://hyperevmscan.io/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63) |
| ValidationRegistry (proxy) | [`0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58`](https://hyperevmscan.io/address/0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58) |

Implementations (identical on both chains): IdentityRegistry `0x7274e874CA62410a93Bd8bf61c69d8045E399c02`, ReputationRegistry `0xEe43505b156f7FbC9c0b2b60E3c3c33eaFe6ea4e`, ValidationRegistry `0x1B325b4035d264FE04f40a632B6798771127C79a`.

**On-chain validation (both networks, all ✅):** bytecode present at all 3 proxies + 3 implementations on each network · each proxy's ERC-1967 implementation slot → MinimalUUPS placeholder (mainnet `0xcB7Af4…F067`, testnet `0xd53dE6…9234`) · all proxies owner-locked to `0x547289319C3e6aedB179C0b8e8aF0B5ACd062603` · cross-registry wiring correct (`_identityRegistry` slot0: Reputation/Validation → Identity, Identity → `0x0`) · `version()` reverts pre-upgrade (proxies still on placeholder). As on any fresh chain, the proxies await the owner's UUPS upgrade to the real implementations.

## How to reproduce

```bash
npm install --legacy-peer-deps   # see note below
# HyperEVM only: enable big blocks on the deployer (IdentityRegistry impl exceeds the small-block gas limit)
#   sign {"type":"evmUserModify","usingBigBlocks":true} — deployer must be a HyperCore user first
npx hardhat run scripts/deploy-vanity.ts --network hyperevmTestnet   # or --network hyperevm
# then the owner runs generate-triple-presigned-upgrade.ts + upgrade-vanity-presigned.ts + verify-vanity.ts
```

## Note for maintainers

The repo currently requires `npm install --legacy-peer-deps`: `@okxweb3/hardhat-explorer-verify` declares a peer dep of `hardhat@^2`, which conflicts with this Hardhat 3 project. Not changed in this PR, just flagging.