### PR TITLE
feat: add NetX mainnet and testnet

### DIFF
--- a/VANITY_DEPLOYMENT_GUIDE.md
+++ b/VANITY_DEPLOYMENT_GUIDE.md
@@ -28,6 +28,8 @@ Owner:              0x547289319C3e6aedB179C0b8e8aF0B5ACd062603
   - Already deployed on mainnet/testnets
   - For localhost: deploy via `scripts/deploy-create2-factory.ts`
 - `OWNER_PRIVATE_KEY` in `.env` for generating pre-signed transactions
+- Optional `UPGRADE_GAS_PRICE_GWEI` in `.env` when the network requires a gas price other than the
+  default `20` gwei. Pre-signed transactions cannot be repriced after generation.
 
 ## Files Involved
 
@@ -57,6 +59,7 @@ npx hardhat run scripts/deploy-create2-factory.ts --network <network>
 npx hardhat run scripts/deploy-vanity.ts --network <network>
 
 # 3. Generate pre-signed upgrade transactions (requires OWNER_PRIVATE_KEY in .env)
+# Set UPGRADE_GAS_PRICE_GWEI first if the network requires a different gas price.
 npx hardhat run scripts/generate-triple-presigned-upgrade.ts --network <network>
 
 # 4. Broadcast the upgrades

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -465,6 +465,24 @@ const config: HardhatUserConfig = {
         }
       }
     },
+    287: {
+      name: "NetX",
+      blockExplorers: {
+        blockscout: {
+          url: "https://netxscan.io",
+          apiUrl: "https://netxscan.io/api",
+        }
+      }
+    },
+    587: {
+      name: "NetX Testnet",
+      blockExplorers: {
+        blockscout: {
+          url: "https://testnet.netxscan.io",
+          apiUrl: "https://testnet.netxscan.io/api",
+        }
+      }
+    },
     5042002: {
       name: "Arc Testnet",
       blockExplorers: {
@@ -786,6 +804,18 @@ const config: HardhatUserConfig = {
       chainType: "op",
       url: process.env.SHAPE_SEPOLIA_RPC_URL || "https://sepolia.shape.network",
       accounts: process.env.SHAPE_SEPOLIA_PRIVATE_KEY ? [process.env.SHAPE_SEPOLIA_PRIVATE_KEY] : [],
+    },
+    netx: {
+      type: "http",
+      chainType: "l1",
+      url: process.env.NETX_RPC_URL || "https://rpc.netxscan.io",
+      accounts: process.env.NETX_PRIVATE_KEY ? [process.env.NETX_PRIVATE_KEY] : [],
+    },
+    netxTestnet: {
+      type: "http",
+      chainType: "l1",
+      url: process.env.NETX_TESTNET_RPC_URL || "https://testnetrpc.netxscan.io",
+      accounts: process.env.NETX_TESTNET_PRIVATE_KEY ? [process.env.NETX_TESTNET_PRIVATE_KEY] : [],
     },
     arcTestnet: {
       type: "http",

--- a/scripts/addresses.ts
+++ b/scripts/addresses.ts
@@ -27,6 +27,7 @@ export const MAINNET_CHAIN_IDS = [
   295,    // Hedera
   1187947933, // SKALE Base
   360,        // Shape
+  287,        // NetX
 ];
 
 /**
@@ -58,6 +59,7 @@ export const TESTNET_CHAIN_IDS = [
   324705682, // SKALE Base Sepolia
   5042002,   // Arc Testnet
   11011,     // Shape Sepolia
+  587,       // NetX Testnet
 ];
 
 /**

--- a/scripts/custom-chains.ts
+++ b/scripts/custom-chains.ts
@@ -35,4 +35,30 @@ export const customChains: Record<string, ReturnType<typeof defineChain>> = {
     nativeCurrency: { name: "USDC", symbol: "USDC", decimals: 18 },
     rpcUrls: { default: { http: ["https://rpc.testnet.arc.network"] } },
   }),
+  netx: defineChain({
+    id: 287,
+    name: "NetX",
+    nativeCurrency: { name: "NetX Token", symbol: "NETX", decimals: 18 },
+    rpcUrls: { default: { http: ["https://rpc.netxscan.io"] } },
+    blockExplorers: {
+      default: {
+        name: "NetXScan",
+        url: "https://netxscan.io",
+        apiUrl: "https://netxscan.io/api",
+      },
+    },
+  }),
+  netxTestnet: defineChain({
+    id: 587,
+    name: "NetX Testnet",
+    nativeCurrency: { name: "NetX Token", symbol: "NETX", decimals: 18 },
+    rpcUrls: { default: { http: ["https://testnetrpc.netxscan.io"] } },
+    blockExplorers: {
+      default: {
+        name: "NetXScan Testnet",
+        url: "https://testnet.netxscan.io",
+        apiUrl: "https://testnet.netxscan.io/api",
+      },
+    },
+  }),
 };

--- a/scripts/generate-triple-presigned-upgrade.ts
+++ b/scripts/generate-triple-presigned-upgrade.ts
@@ -1,8 +1,9 @@
 import hre from "hardhat";
-import { encodeFunctionData, Hex, parseGwei, keccak256, getCreate2Address } from "viem";
+import { createPublicClient, encodeFunctionData, Hex, http, parseGwei, keccak256, getCreate2Address } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import dotenv from "dotenv";
 import fs from "fs";
+import { customChains } from "./custom-chains";
 import {
   SAFE_SINGLETON_FACTORY,
   IMPLEMENTATION_SALTS,
@@ -18,8 +19,20 @@ dotenv.config();
  * Simple approach: one transaction per upgrade, sequential nonces
  */
 async function main() {
-  const { viem } = await hre.network.connect();
-  const publicClient = await viem.getPublicClient();
+  const networkIdx = process.argv.indexOf("--network");
+  const networkName = networkIdx !== -1 ? process.argv[networkIdx + 1] : undefined;
+  const custom = networkName ? customChains[networkName] : undefined;
+
+  let publicClient: any;
+  if (custom) {
+    publicClient = createPublicClient({
+      chain: custom,
+      transport: http(custom.rpcUrls.default.http[0]),
+    });
+  } else {
+    const { viem } = await hre.network.connect();
+    publicClient = await viem.getPublicClient();
+  }
   const chainId = await publicClient.getChainId();
 
   // Get network-specific config
@@ -87,8 +100,11 @@ async function main() {
   // Get MinimalUUPS artifact for upgradeToAndCall
   const minimalUUPSArtifact = await hre.artifacts.readArtifact("MinimalUUPS");
 
-  // Gas settings
-  const gasPrice = parseGwei("20"); // 20 gwei
+  // Signed transactions cannot be repriced after generation.
+  const gasPriceGwei = process.env.UPGRADE_GAS_PRICE_GWEI || "20";
+  const gasPrice = parseGwei(gasPriceGwei);
+  console.log("Gas price:", `${gasPriceGwei} gwei`);
+  console.log("");
 
   // Encode initialize() calls for each implementation
   const identityInitData = encodeFunctionData({

--- a/scripts/upgrade-vanity-presigned.ts
+++ b/scripts/upgrade-vanity-presigned.ts
@@ -1,12 +1,17 @@
 import hre from "hardhat";
-import { Hex, keccak256, getCreate2Address } from "viem";
+import { createPublicClient, createWalletClient, Hex, http, keccak256, getCreate2Address } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import dotenv from "dotenv";
 import fs from "fs";
+import { customChains } from "./custom-chains";
 import {
   SAFE_SINGLETON_FACTORY,
   IMPLEMENTATION_SALTS,
   getAddresses,
   getNetworkType,
 } from "./addresses";
+
+dotenv.config();
 
 /**
  * Upgrade vanity proxies using PRE-EXISTING pre-signed transactions
@@ -20,9 +25,29 @@ import {
  * This script only loads and broadcasts the existing signatures.
  */
 async function main() {
-  const { viem } = await hre.network.connect();
-  const publicClient = await viem.getPublicClient();
-  const [deployer] = await viem.getWalletClients();
+  const networkIdx = process.argv.indexOf("--network");
+  const networkName = networkIdx !== -1 ? process.argv[networkIdx + 1] : undefined;
+  const custom = networkName ? customChains[networkName] : undefined;
+
+  let publicClient: any;
+  let deployer: any;
+
+  if (custom) {
+    const rpcUrl = custom.rpcUrls.default.http[0];
+    const pkEnv = `${networkName!.replace(/([A-Z])/g, "_$1").toUpperCase()}_PRIVATE_KEY`;
+    const pk = process.env[pkEnv];
+    if (!pk) throw new Error(`Set ${pkEnv} in your .env`);
+    publicClient = createPublicClient({ chain: custom, transport: http(rpcUrl) });
+    deployer = createWalletClient({
+      account: privateKeyToAccount(pk as Hex),
+      chain: custom,
+      transport: http(rpcUrl),
+    });
+  } else {
+    const { viem } = await hre.network.connect();
+    publicClient = await viem.getPublicClient();
+    [deployer] = await viem.getWalletClients();
+  }
   const chainId = await publicClient.getChainId();
 
   // Get network-specific config


### PR DESCRIPTION
## Summary

- add NetX mainnet (`287`) and NetX testnet (`587`) to the supported chain lists
- add Hardhat RPC and Blockscout configuration for both networks
- add custom viem chain definitions and use them in the pre-signed deployment flow
- make the pre-signed upgrade gas price configurable through `UPGRADE_GAS_PRICE_GWEI`, while
  retaining the existing `20 gwei` default

## Deployment prerequisites

The Safe Singleton Factory is deployed at
`0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7` on both networks:

- Mainnet artifact: https://github.com/safe-fndn/safe-singleton-factory/blob/main/artifacts/287/deployment.json
- Testnet artifact: https://github.com/safe-fndn/safe-singleton-factory/blob/main/artifacts/587/deployment.json
- Mainnet deployment PR: https://github.com/safe-fndn/safe-singleton-factory/pull/1440
- Testnet deployment PR: https://github.com/safe-fndn/safe-singleton-factory/pull/1441
- Chainlist correction PR: https://github.com/DefiLlama/chainlist/pull/2940

On 2026-08-05, read-only RPC checks confirmed:

- the RPC chain IDs are `287` and `587`
- both networks report `300 gwei` from `eth_gasPrice`
- the ERC-8004 owner nonce is `0` on both networks
- all six expected registry addresses are empty
- both networks support the Shanghai `PUSH0` opcode

## Validation

- `npx hardhat compile`
- `npm test` (`79` tests passing)
- connected to both RPCs through the new custom viem chain definitions
- recalculated all six proxy addresses from the compiled bytecode and CREATE2 salts; all match the
  expected mainnet and testnet address sets

No deployment transaction was signed or broadcast by this PR.
